### PR TITLE
[M2] Update all scenario: keys to match experiment_N data folder names

### DIFF
--- a/configs/experiment_1_dgm_gradnorm.yaml
+++ b/configs/experiment_1_dgm_gradnorm.yaml
@@ -4,7 +4,7 @@ training:
   epochs: 20_000
   learning_rate: 0.0023774931714941583
   batch_size: 256
-scenario: one_building_DEM_zero
+scenario: experiment_2
 model:
   name: DGMNetwork
   output_dim: 3

--- a/configs/experiment_1_dgm_static.yaml
+++ b/configs/experiment_1_dgm_static.yaml
@@ -6,7 +6,7 @@ training:
   epochs: 20000
   learning_rate: 0.0032659720145241655
   batch_size: 1024
-scenario: one_building_DEM_zero
+scenario: experiment_2
 model:
   name: DGMNetwork
   output_dim: 3

--- a/configs/experiment_3.yaml
+++ b/configs/experiment_3.yaml
@@ -1,4 +1,4 @@
-scenario: benchmark_test_1
+scenario: experiment_3
 domain:
   lx: 700.0
   ly: 100.0

--- a/configs/experiment_3_pix2pix.yaml
+++ b/configs/experiment_3_pix2pix.yaml
@@ -1,5 +1,5 @@
 CONFIG_PATH: "configs/pix2pix_test1.yaml"
-scenario: "benchmark_test_1"
+scenario: experiment_3
 
 domain:
   lx: 700.0

--- a/configs/experiment_4.yaml
+++ b/configs/experiment_4.yaml
@@ -1,4 +1,4 @@
-scenario: benchmark_test_2
+scenario: experiment_4
 domain:
   lx: 2000.0
   ly: 2000.0

--- a/configs/experiment_5.yaml
+++ b/configs/experiment_5.yaml
@@ -1,4 +1,4 @@
-scenario: benchmark_test_3
+scenario: experiment_5
 domain:
   lx: 300.0
   ly: 100.0

--- a/configs/experiment_6.yaml
+++ b/configs/experiment_6.yaml
@@ -1,4 +1,4 @@
-scenario: benchmark_test_4
+scenario: experiment_6
 domain:
   lx: 1000.0
   ly: 2000.0

--- a/configs/experiment_7.yaml
+++ b/configs/experiment_7.yaml
@@ -1,4 +1,4 @@
-scenario: benchmark_test_5
+scenario: experiment_7
 domain:
   t_final: 108000.0         # 30 hours
 physics:

--- a/configs/experiment_8.yaml
+++ b/configs/experiment_8.yaml
@@ -1,4 +1,4 @@
-scenario: experiment_6
+scenario: experiment_8
 domain:
   t_final: 21600.0         # 6 hours
 physics:

--- a/configs/train/experiment_1_dgm_final.yaml
+++ b/configs/train/experiment_1_dgm_final.yaml
@@ -1,4 +1,4 @@
-scenario: no_building_scenario
+scenario: experiment_1
 domain:
   lx: 1200.0
   ly: 100.0

--- a/configs/train/experiment_1_fourier_final.yaml
+++ b/configs/train/experiment_1_fourier_final.yaml
@@ -1,4 +1,4 @@
-scenario: no_building_scenario
+scenario: experiment_1
 domain:
   lx: 1200.0
   ly: 100.0

--- a/configs/train/experiment_1_mlp_final.yaml
+++ b/configs/train/experiment_1_mlp_final.yaml
@@ -1,4 +1,4 @@
-scenario: no_building_scenario
+scenario: experiment_1
 domain:
   lx: 1200.0
   ly: 100.0

--- a/configs/train/experiment_2_dgm_final.yaml
+++ b/configs/train/experiment_2_dgm_final.yaml
@@ -1,4 +1,4 @@
-scenario: one_building_DEM_zero
+scenario: experiment_2
 domain:
   lx: 1200.0
   ly: 100.0

--- a/configs/train/experiment_2_fourier_final.yaml
+++ b/configs/train/experiment_2_fourier_final.yaml
@@ -1,4 +1,4 @@
-scenario: one_building_DEM_zero
+scenario: experiment_2
 domain:
   lx: 1200.0
   ly: 100.0

--- a/optimisation/configs/exploitation/hpo_exploitation_dgm_building.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_dgm_building.yaml
@@ -1,5 +1,5 @@
 hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}
 device: {dtype: float32, early_stop_min_epochs: 4000, early_stop_patience: 3000}

--- a/optimisation/configs/exploitation/hpo_exploitation_dgm_nobuilding.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_dgm_nobuilding.yaml
@@ -1,5 +1,5 @@
 hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
-scenario: "no_building_scenario"
+scenario: experiment_1
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}
 device: {dtype: float32, early_stop_min_epochs: 4000, early_stop_patience: 3000}

--- a/optimisation/configs/exploitation/hpo_exploitation_fourier_building.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_fourier_building.yaml
@@ -1,5 +1,5 @@
 hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}
 device: {dtype: float32, early_stop_min_epochs: 4000, early_stop_patience: 3000}

--- a/optimisation/configs/exploitation/hpo_exploitation_fourier_nobuilding.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_fourier_nobuilding.yaml
@@ -1,5 +1,5 @@
 hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
-scenario: "no_building_scenario"
+scenario: experiment_1
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}
 device: {dtype: float32, early_stop_min_epochs: 4000, early_stop_patience: 3000}

--- a/optimisation/configs/exploitation/hpo_exploitation_mlp_building.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_mlp_building.yaml
@@ -1,5 +1,5 @@
 hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}
 device: {dtype: float32, early_stop_min_epochs: 4000, early_stop_patience: 3000}

--- a/optimisation/configs/exploitation/hpo_exploitation_mlp_nobuilding.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_mlp_nobuilding.yaml
@@ -1,5 +1,5 @@
 hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
-scenario: "no_building_scenario"
+scenario: experiment_1
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}
 device: {dtype: float32, early_stop_min_epochs: 4000, early_stop_patience: 3000}

--- a/optimisation/configs/exploration/archive/hpo_DGM_datafree_gradnorm.yaml
+++ b/optimisation/configs/exploration/archive/hpo_DGM_datafree_gradnorm.yaml
@@ -12,7 +12,7 @@ training: # <<<--- Add seed here
   # opt_epochs is added by run_optimization based on hpo_settings
 
 # --- Fixed Parameters ---
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 
 model:
   name: "DGMNetwork"

--- a/optimisation/configs/exploration/archive/hpo_DGM_datafree_static.yaml
+++ b/optimisation/configs/exploration/archive/hpo_DGM_datafree_static.yaml
@@ -12,7 +12,7 @@ training: # <<<--- Add seed here
   # opt_epochs is added by run_optimization based on hpo_settings
 
 # --- Fixed Parameters ---
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 
 model:
   name: "DGMNetwork"

--- a/optimisation/configs/exploration/archive/hpo_fourier_datafree_static.yaml
+++ b/optimisation/configs/exploration/archive/hpo_fourier_datafree_static.yaml
@@ -12,7 +12,7 @@ training: # <<<--- Add seed here
   # opt_epochs is added by run_optimization based on hpo_settings
 
 # --- Fixed Parameters ---
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 
 model:
   name: "FourierPINN"

--- a/optimisation/configs/exploration/hpo_dgm_datafree_static_BUILDING.yaml
+++ b/optimisation/configs/exploration/hpo_dgm_datafree_static_BUILDING.yaml
@@ -8,7 +8,7 @@ hpo_settings:
 training:
   seed: 42
 
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 
 model:
   name: "DGMNetwork"

--- a/optimisation/configs/exploration/hpo_fourier_datafree_static_BUILDING.yaml
+++ b/optimisation/configs/exploration/hpo_fourier_datafree_static_BUILDING.yaml
@@ -10,7 +10,7 @@ hpo_settings:
 training:
   seed: 42
 
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 
 model:
   name: "FourierPINN"

--- a/optimisation/configs/exploration/hpo_mlp_datafree_static_BUILDING.yaml
+++ b/optimisation/configs/exploration/hpo_mlp_datafree_static_BUILDING.yaml
@@ -8,7 +8,7 @@ hpo_settings:
 training:
   seed: 42
 
-scenario: "one_building_DEM_zero"
+scenario: experiment_2
 
 model:
   name: "MLP"

--- a/scripts/create_samples.py
+++ b/scripts/create_samples.py
@@ -239,7 +239,7 @@ if __name__ == "__main__":
         description="Create time-filtered training and validation samples from a large .npy tensor."
     )
     parser.add_argument(
-        "--scenario", type=str, default="one_building_DEM_zero", help="Scenario directory under ./data/"
+        "--scenario", type=str, default="experiment_2", help="Scenario directory under ./data/"
     )
     parser.add_argument(
         "--val_samples", type=int, default=65536, help="Number of validation samples (default: 65536)"

--- a/src/scenarios/experiment_3/experiment_3.py
+++ b/src/scenarios/experiment_3/experiment_3.py
@@ -300,7 +300,7 @@ def main(config_path: str):
         # Log basics
         hparams_to_log = copy.deepcopy(cfg_dict)
         aim_run["hparams"] = hparams_to_log
-        aim_run['flags'] = {"scenario_type": "benchmark_test_1"}
+        aim_run['flags'] = {"scenario_type": "experiment_3"}
         
         # --- Log Config and Script as Artifacts ---
         try:

--- a/src/scenarios/experiment_4/experiment_4.py
+++ b/src/scenarios/experiment_4/experiment_4.py
@@ -291,7 +291,7 @@ def main(config_path: str):
         # Log basics
         hparams_to_log = copy.deepcopy(cfg_dict)
         aim_run["hparams"] = hparams_to_log
-        aim_run['flags'] = {"scenario_type": "benchmark_test_2"}
+        aim_run['flags'] = {"scenario_type": "experiment_4"}
 
         # --- Log Config and Script as Artifacts ---
         try:

--- a/src/scenarios/experiment_5/experiment_5.py
+++ b/src/scenarios/experiment_5/experiment_5.py
@@ -291,7 +291,7 @@ def main(config_path: str):
         # Log basics
         hparams_to_log = copy.deepcopy(cfg_dict)
         aim_run["hparams"] = hparams_to_log
-        aim_run['flags'] = {"scenario_type": "benchmark_test_1"}
+        aim_run['flags'] = {"scenario_type": "experiment_5"}
         
         # --- Log Config and Script as Artifacts ---
         try:

--- a/src/scenarios/experiment_6/experiment_6.py
+++ b/src/scenarios/experiment_6/experiment_6.py
@@ -284,7 +284,7 @@ def main(config_path: str):
         # Log basics
         hparams_to_log = copy.deepcopy(cfg_dict)
         aim_run["hparams"] = hparams_to_log
-        aim_run['flags'] = {"scenario_type": "benchmark_test_2"}
+        aim_run['flags'] = {"scenario_type": "experiment_6"}
 
         # --- Log Config and Script as Artifacts ---
         try:

--- a/src/scenarios/experiment_7/experiment_7.py
+++ b/src/scenarios/experiment_7/experiment_7.py
@@ -316,7 +316,7 @@ def main(config_path: str):
         # Log basics
         hparams_to_log = copy.deepcopy(cfg_dict)
         aim_run["hparams"] = hparams_to_log
-        aim_run['flags'] = {"scenario_type": "benchmark_test_5"}
+        aim_run['flags'] = {"scenario_type": "experiment_7"}
 
         # --- Log Config and Script as Artifacts ---
         try:


### PR DESCRIPTION
## Summary
- **Modified** 9 experiment configs — replaced `benchmark_test_*` with `experiment_N`
- **Modified** 5 train/ configs — replaced `no_building_scenario`/`one_building_DEM_zero` with `experiment_1`/`experiment_2`
- **Modified** 9 HPO configs (exploration + exploitation) — same legacy name replacements
- **Modified** 5 experiment scripts — updated Aim `scenario_type` flags
- **Modified** `scripts/create_samples.py` — updated default scenario arg

## Test plan
- [x] `grep -rn 'benchmark_test_\|no_building_scenario\|one_building_DEM_zero' --include='*.yaml'` returns no matches
- [x] All `data/experiment_N/` folders exist (2–8)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)