### PR TITLE
[M4] Extract shared load_validation_data() utility

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -30,6 +30,21 @@ def sample_points(x_start: float, x_end: float, y_start: float, y_end: float,
     
     return jnp.hstack([x_coords, y_coords, t_coords])
 
+def load_validation_data(path: str, dtype=None):
+    """Load validation data, reordering columns from [t,x,y,...] to [x,y,t].
+
+    Returns:
+        raw_data: Full loaded array (for plotting)
+        inputs: Reordered coordinates [x, y, t]
+        targets: Target values [h, hu, hv]
+    """
+    data = np.load(path)
+    if dtype is not None:
+        data = data.astype(dtype)
+    inputs = data[:, [1, 2, 0]]   # [x, y, t]
+    targets = data[:, 3:6]         # [h, hu, hv]
+    return data, inputs, targets
+
 def get_batches(key: jax.random.PRNGKey, data: jnp.ndarray, batch_size: int) -> list:
     """Shuffle and split data into batches, dropping the remainder."""
     data = jax.random.permutation(key, data, axis=0)

--- a/src/scenarios/experiment_2/experiment_2.py
+++ b/src/scenarios/experiment_2/experiment_2.py
@@ -35,7 +35,7 @@ if project_root not in sys.path:
     print(f"Added project root to path: {project_root}")
 
 from src.config import load_config, DTYPE
-from src.data import sample_domain, get_batches, get_batches_tensor, get_sample_count
+from src.data import sample_domain, get_batches, get_batches_tensor, get_sample_count, load_validation_data
 from src.models import init_model
 from src.losses import (
     compute_pde_loss, compute_ic_loss, compute_bc_loss, total_loss,
@@ -248,10 +248,8 @@ def main(config_path: str):
     if os.path.exists(validation_data_file):
         try:
             print(f"Loading VALIDATION data from: {validation_data_file}")
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-
-            val_points_all = loaded_val_data[:, [1, 2, 0]]
-            h_true_val_all = loaded_val_data[:, 3]
+            _, val_points_all, val_targets_all = load_validation_data(validation_data_file, dtype=DTYPE)
+            h_true_val_all = val_targets_all[:, 0]
             print("Applying building mask to validation metrics points...")
             mask_val = mask_points_inside_building(val_points_all, cfg["building"])
             val_points = val_points_all[mask_val]

--- a/src/scenarios/experiment_3/experiment_3.py
+++ b/src/scenarios/experiment_3/experiment_3.py
@@ -28,7 +28,8 @@ from src.data import (
     bathymetry_fn,
     load_boundary_condition,
     load_bathymetry,
-    sample_lhs 
+    sample_lhs,
+    load_validation_data,
 )
 from src.models import init_model
 from src.losses import (
@@ -261,10 +262,8 @@ def main(config_path: str):
     if os.path.exists(validation_data_file):
         try:
             print(f"Loading VALIDATION data from: {validation_data_file}")
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-            full_val_data = loaded_val_data # Keep reference to full data for plotting
-            val_points = loaded_val_data[:, [1, 2, 0]]
-            h_true_val = loaded_val_data[:, 3]
+            full_val_data, val_points, val_targets = load_validation_data(validation_data_file, dtype=DTYPE)
+            h_true_val = val_targets[:, 0]
             num_val_points = val_points.shape[0]
             if num_val_points > 0:
                 validation_data_loaded = True

--- a/src/scenarios/experiment_4/experiment_4.py
+++ b/src/scenarios/experiment_4/experiment_4.py
@@ -29,7 +29,8 @@ from src.data import (
     bathymetry_fn,
     load_boundary_condition,
     load_bathymetry,
-    sample_lhs 
+    sample_lhs,
+    load_validation_data,
 )
 from src.models import init_model
 from src.losses import (
@@ -253,10 +254,8 @@ def main(config_path: str):
     if os.path.exists(validation_data_file):
         try:
             print(f"Loading VALIDATION data from: {validation_data_file}")
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-            full_val_data = loaded_val_data 
-            val_points = loaded_val_data[:, [1, 2, 0]]
-            h_true_val = loaded_val_data[:, 3]
+            full_val_data, val_points, val_targets = load_validation_data(validation_data_file, dtype=DTYPE)
+            h_true_val = val_targets[:, 0]
             num_val_points = val_points.shape[0]
             if num_val_points > 0:
                 validation_data_loaded = True

--- a/src/scenarios/experiment_5/experiment_5.py
+++ b/src/scenarios/experiment_5/experiment_5.py
@@ -28,7 +28,8 @@ from src.data import (
     bathymetry_fn,
     load_boundary_condition,
     load_bathymetry,
-    sample_lhs 
+    sample_lhs,
+    load_validation_data,
 )
 from src.models import init_model
 from src.losses import (
@@ -252,10 +253,8 @@ def main(config_path: str):
     if os.path.exists(validation_data_file):
         try:
             print(f"Loading VALIDATION data from: {validation_data_file}")
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-            full_val_data = loaded_val_data # Keep reference to full data for plotting
-            val_points = loaded_val_data[:, [1, 2, 0]]
-            h_true_val = loaded_val_data[:, 3]
+            full_val_data, val_points, val_targets = load_validation_data(validation_data_file, dtype=DTYPE)
+            h_true_val = val_targets[:, 0]
             num_val_points = val_points.shape[0]
             if num_val_points > 0:
                 validation_data_loaded = True

--- a/src/scenarios/experiment_6/experiment_6.py
+++ b/src/scenarios/experiment_6/experiment_6.py
@@ -29,7 +29,8 @@ from src.data import (
     bathymetry_fn,
     load_boundary_condition,
     load_bathymetry,
-    sample_lhs 
+    sample_lhs,
+    load_validation_data,
 )
 from src.models import init_model
 from src.losses import (
@@ -246,10 +247,8 @@ def main(config_path: str):
     if os.path.exists(validation_data_file):
         try:
             print(f"Loading VALIDATION data from: {validation_data_file}")
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-            full_val_data = loaded_val_data 
-            val_points = loaded_val_data[:, [1, 2, 0]]
-            h_true_val = loaded_val_data[:, 3]
+            full_val_data, val_points, val_targets = load_validation_data(validation_data_file, dtype=DTYPE)
+            h_true_val = val_targets[:, 0]
             num_val_points = val_points.shape[0]
             if num_val_points > 0:
                 validation_data_loaded = True

--- a/src/scenarios/experiment_7/experiment_7.py
+++ b/src/scenarios/experiment_7/experiment_7.py
@@ -27,7 +27,8 @@ from src.data import (
     get_sample_count,
     load_boundary_condition,
     IrregularDomainSampler,
-    load_bathymetry
+    load_bathymetry,
+    load_validation_data,
 )
 from src.models import init_model
 from src.losses import (
@@ -278,10 +279,8 @@ def main(config_path: str):
     if os.path.exists(validation_data_file):
         try:
             print(f"Loading VALIDATION data from: {validation_data_file}")
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-            full_val_data = loaded_val_data 
-            val_points = loaded_val_data[:, [1, 2, 0]]
-            h_true_val = loaded_val_data[:, 3]
+            full_val_data, val_points, val_targets = load_validation_data(validation_data_file, dtype=DTYPE)
+            h_true_val = val_targets[:, 0]
             num_val_points = val_points.shape[0]
             if num_val_points > 0:
                 validation_data_loaded = True

--- a/src/scenarios/experiment_8/experiment_8.py
+++ b/src/scenarios/experiment_8/experiment_8.py
@@ -29,7 +29,8 @@ from src.data import (
     get_sample_count,
     load_boundary_condition,
     IrregularDomainSampler,
-    load_bathymetry
+    load_bathymetry,
+    load_validation_data,
 )
 from src.models import init_model
 from src.losses import (
@@ -286,16 +287,10 @@ def main(config_path: str):
     if os.path.exists(validation_data_file):
         try:
             print(f"Loading VALIDATION data from: {validation_data_file}")
-            # Loaded shape: [N, 6] -> t, x, y, h, u, v
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-            
-            # Prepare inputs: [x, y, t]
-            val_pts_batch = loaded_val_data[:, [1, 2, 0]]
-            
-            # Prepare Targets: h, hu, hv
-            val_h_true = loaded_val_data[:, 3]
-            u_temp = loaded_val_data[:, 4]
-            v_temp = loaded_val_data[:, 5]
+            _, val_pts_batch, val_targets = load_validation_data(validation_data_file, dtype=DTYPE)
+            val_h_true = val_targets[:, 0]
+            u_temp = val_targets[:, 1]
+            v_temp = val_targets[:, 2]
             
             val_hu_true = val_h_true * u_temp
             val_hv_true = val_h_true * v_temp

--- a/src/scenarios/experiment_8/experiment_8_imp_samp.py
+++ b/src/scenarios/experiment_8/experiment_8_imp_samp.py
@@ -34,7 +34,8 @@ from src.data import (
     load_boundary_condition,
     IrregularDomainSampler,
     load_bathymetry,
-    bathymetry_fn 
+    bathymetry_fn,
+    load_validation_data,
 )
 from src.models import init_model
 from src.losses import (
@@ -361,11 +362,10 @@ def main(config_path: str):
 
     if os.path.exists(validation_data_file):
         try:
-            loaded_val_data = jnp.load(validation_data_file).astype(DTYPE)
-            val_pts_batch = loaded_val_data[:, [1, 2, 0]]
-            val_h_true = loaded_val_data[:, 3]
-            u_temp = loaded_val_data[:, 4]
-            v_temp = loaded_val_data[:, 5]
+            _, val_pts_batch, val_targets = load_validation_data(validation_data_file, dtype=DTYPE)
+            val_h_true = val_targets[:, 0]
+            u_temp = val_targets[:, 1]
+            v_temp = val_targets[:, 2]
             val_hu_true = val_h_true * u_temp
             val_hv_true = val_h_true * v_temp
             if val_pts_batch.shape[0] > 0:


### PR DESCRIPTION
## Summary
- **Added** `load_validation_data(path, dtype)` to `src/data.py` — centralises column reordering `[t,x,y]` → `[x,y,t]` and target extraction
- **Modified** 8 experiment scripts to use the shared utility:
  - `experiment_2.py` — validation loading
  - `experiment_3.py` — validation loading
  - `experiment_4.py` — validation loading
  - `experiment_5.py` — validation loading
  - `experiment_6.py` — validation loading
  - `experiment_7.py` — validation loading
  - `experiment_8.py` — validation loading
  - `experiment_8_imp_samp.py` — validation loading

## Test plan
- [x] Only one remaining `[:, [1, 2, 0]]` in codebase (experiment_2 plot data — different context)
- [x] All scripts import and use the shared function

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)