### PR TITLE
[M4] Standardise loss_slip_wall_generalized signature

### DIFF
--- a/src/losses.py
+++ b/src/losses.py
@@ -133,7 +133,7 @@ def loss_slip_wall_generalized(model, params, batch):
     coords = batch[..., :3]     # Input to model
     normals = batch[..., 3:5]   # Normals [nx, ny]
     
-    U = model.apply(params, coords, train=True)
+    U = model.apply({'params': params['params']}, coords, train=False)
     
     # U = [h, hu, hv]
     hu = U[..., 1]


### PR DESCRIPTION
## Summary
- **Modified** `src/losses.py` — changed `model.apply(params, coords, train=True)` to `model.apply({'params': params['params']}, coords, train=False)` in `loss_slip_wall_generalized()`, consistent with all other loss functions

No caller changes needed — all callers already pass the same params dict.

## Test plan
- [x] All callers in experiment_7, experiment_8, experiment_8_imp_samp pass params identically
- [x] Change is purely internal to how model.apply is invoked

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)