### PR TITLE
[M4] Add bathymetry load warning instead of silent zero fallback

### DIFF
--- a/src/data.py
+++ b/src/data.py
@@ -235,13 +235,23 @@ def load_bathymetry(dem_path: str):
     _BATHYMETRY_FN = vmap(bathymetry_fn_point)
     print(f"Bathymetry loaded from {dem_path}")
 
+_BATHYMETRY_WARNING_EMITTED = False
+
 def bathymetry_fn(x, y):
     """
     Public accessor for the bathymetry function.
     Can be imported by losses.py.
     """
+    global _BATHYMETRY_WARNING_EMITTED
     if _BATHYMETRY_FN is None:
-        # Fallback: Flat bed (0 slope)
+        if not _BATHYMETRY_WARNING_EMITTED:
+            import warnings
+            warnings.warn(
+                "Bathymetry not loaded — using flat domain (z=0). "
+                "Call load_bathymetry() first if terrain is expected.",
+                stacklevel=2
+            )
+            _BATHYMETRY_WARNING_EMITTED = True
         return jnp.zeros_like(x), jnp.zeros_like(x), jnp.zeros_like(x)
     return _BATHYMETRY_FN(x, y)
 


### PR DESCRIPTION
## Summary
- **Modified** `src/data.py` — `bathymetry_fn()` now emits a `warnings.warn()` on first call when `_BATHYMETRY_FN is None`, instead of silently returning zeros

## Test plan
- [x] Warning only emitted once (uses `_BATHYMETRY_WARNING_EMITTED` flag)
- [x] Zero fallback behavior preserved for flat-domain experiments

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)