### PR TITLE
[M5] Replace hardcoded absolute paths with relative paths

### DIFF
--- a/optimisation/extract_best_params.py
+++ b/optimisation/extract_best_params.py
@@ -3,9 +3,11 @@ import os
 import yaml
 from pathlib import Path
 
+_SCRIPT_DIR = Path(__file__).resolve().parent
+
 def extract_best_trials():
-    db_dir = Path("/workspaces/swe-pinn/optimisation/database/exploration")
-    output_base_dir = Path("/workspaces/swe-pinn/optimisation/sensitivity_analysis_output/best_parameters")
+    db_dir = _SCRIPT_DIR / "database" / "exploration"
+    output_base_dir = _SCRIPT_DIR / "sensitivity_analysis_output" / "best_parameters"
     
     if not db_dir.exists():
         print(f"Source directory {db_dir} does not exist.")


### PR DESCRIPTION
## Summary
- **Modified** `optimisation/extract_best_params.py` — replaced `/workspaces/swe-pinn/` absolute paths with `Path(__file__).resolve().parent`-relative paths

## Test plan
- [x] `grep -rn '/workspaces/swe-pinn' --include='*.py' --include='*.sh'` returns no matches
- [x] Script works from any working directory

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)