### PR TITLE
[M6] Add docstrings to all public functions in core modules

### DIFF
--- a/src/losses.py
+++ b/src/losses.py
@@ -260,6 +260,7 @@ def compute_data_loss(model: nn.Module, params: Dict[str, Any], data_batch: jnp.
             jnp.mean((hv_pred - hv_true)**2))
 
 def total_loss(terms: Dict[str, jnp.ndarray], weights: Dict[str, float]) -> jnp.ndarray:
+    """Combine weighted loss terms into a single scalar loss."""
     loss = 0.0
     for key in terms.keys():
         if key in weights:

--- a/src/models.py
+++ b/src/models.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Tuple, Sequence
 from src.config import DTYPE
 
 class Normalize(nn.Module):
+    """Normalizes spatial and temporal coordinates to [-1, 1] range."""
     lx: float
     ly: float
     t_final: float
@@ -22,6 +23,7 @@ class Normalize(nn.Module):
         return jnp.stack([x_scaled, y_scaled, t_scaled], axis=-1)
 
 class FourierFeatures(nn.Module):
+    """Projects inputs into higher-dimensional frequency space to overcome spectral bias."""
     output_dims: int
     scale: float
 
@@ -300,6 +302,7 @@ class FourierDeepONet(nn.Module):
         return output
 
 def init_deeponet_model(model_class: nn.Module, key: jax.random.PRNGKey, config: Dict[str, Any]) -> Tuple[nn.Module, Dict[str, Any]]:
+    """Initialize a DeepONet model with branch and trunk networks."""
     model = model_class(config=config)
     param_names = tuple(config["physics"]["param_bounds"].keys())
     n_params = len(param_names)


### PR DESCRIPTION
## Summary
- **Modified** `src/models.py` — added docstrings to `Normalize`, `FourierFeatures`, `init_deeponet_model`
- **Modified** `src/losses.py` — added docstring to `total_loss`
- Most other public functions in core modules already had docstrings

## Test plan
- [x] All public functions/classes in core modules now have docstrings

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)