### PR TITLE
[M6] Add module-level docstrings to each experiment script

### DIFF
--- a/src/scenarios/experiment_1/experiment_1.py
+++ b/src/scenarios/experiment_1/experiment_1.py
@@ -1,6 +1,8 @@
-"""
-Training script for the "analytical" (no-building) scenario for the
-Shallow Water Equation (SWE) PINN model.
+"""Experiment 1 — Analytical dam-break on flat domain (Phase 1).
+
+Verifies the PINN framework against an analytical dam-break solution.
+Requires: configs/experiment_1_*.yaml
+Builds on: None (baseline verification).
 
 This script handles both data-free and data-driven (analytical) training modes.
 It supports static loss weighting and provides

--- a/src/scenarios/experiment_2/experiment_2.py
+++ b/src/scenarios/experiment_2/experiment_2.py
@@ -1,6 +1,8 @@
-"""
-Training script for the "building" scenario for the
-Shallow Water Equation (SWE) PINN model.
+"""Experiment 2 — Dam-break with building obstacle (Phase 1).
+
+Introduces a building obstacle; motivates Fourier-MLP and DGM adoption.
+Requires: configs/experiment_2_*.yaml, data/experiment_2/
+Builds on: Experiment 1.
 
 This script handles training for scenarios with building
 structures. It supports static loss weighting and provides

--- a/src/scenarios/experiment_3/experiment_3.py
+++ b/src/scenarios/experiment_3/experiment_3.py
@@ -1,3 +1,10 @@
+"""Experiment 3 — Terrain slope in x-direction (Phase 2).
+
+Introduces terrain via bi-linear DEM interpolation; establishes data
+sampling ratio methodology when physics-only training is insufficient.
+Requires: configs/experiment_3.yaml, data/experiment_3/
+Builds on: Experiment 2.
+"""
 import os
 import sys
 import time

--- a/src/scenarios/experiment_4/experiment_4.py
+++ b/src/scenarios/experiment_4/experiment_4.py
@@ -1,3 +1,9 @@
+"""Experiment 4 — Terrain slope in x+y directions (Phase 2).
+
+Extends terrain slope to both x and y directions.
+Requires: configs/experiment_4.yaml, data/experiment_4/
+Builds on: Experiment 3.
+"""
 import os
 import sys
 import time

--- a/src/scenarios/experiment_5/experiment_5.py
+++ b/src/scenarios/experiment_5/experiment_5.py
@@ -1,3 +1,9 @@
+"""Experiment 5 — Synthetic complexity stage 1 (Phase 2).
+
+Validates robustness on increasingly complex synthetic domains.
+Requires: configs/experiment_5.yaml, data/experiment_5/
+Builds on: Experiment 4.
+"""
 import os
 import sys
 import time

--- a/src/scenarios/experiment_7/experiment_7.py
+++ b/src/scenarios/experiment_7/experiment_7.py
@@ -1,3 +1,10 @@
+"""Experiment 7 — Irregular boundaries with mesh-based sampling (Phase 3).
+
+Tackles non-rectangular domains using triangulated mesh sampling,
+automated boundary detection, and computed wall normals for slip BCs.
+Requires: configs/experiment_7.yaml, data/experiment_7/
+Builds on: Experiment 5.
+"""
 import os
 import sys
 import time

--- a/src/scenarios/experiment_8/experiment_8.py
+++ b/src/scenarios/experiment_8/experiment_8.py
@@ -1,3 +1,10 @@
+"""Experiment 8 — Real urban domain, Eastbourne UK (Phase 3).
+
+Applies the framework to a real urban subcatchment (Blue Heart Project).
+Buildings excluded from mesh by construction, treated as wall boundaries.
+Requires: configs/experiment_8.yaml, data/experiment_8/
+Builds on: Experiment 7.
+"""
 import os
 import sys
 import time

--- a/src/scenarios/experiment_8/experiment_8_imp_samp.py
+++ b/src/scenarios/experiment_8/experiment_8_imp_samp.py
@@ -1,3 +1,10 @@
+"""Experiment 8 — Importance sampling variant (Phase 3).
+
+Same domain as Experiment 8 but uses error-driven adaptive importance
+sampling to concentrate collocation points in high-residual regions.
+Requires: configs/experiment_8.yaml, data/experiment_8/
+Builds on: Experiment 8.
+"""
 import os
 import sys
 import time


### PR DESCRIPTION
## Summary
- **Modified** 8 experiment scripts with module-level docstrings including research phase, purpose, requirements, and lineage:
  - `experiment_1.py` — Phase 1: analytical dam-break
  - `experiment_2.py` — Phase 1: building obstacle
  - `experiment_3.py` — Phase 2: x-direction terrain slope
  - `experiment_4.py` — Phase 2: x+y terrain slope
  - `experiment_5.py` — Phase 2: synthetic complexity
  - `experiment_7.py` — Phase 3: irregular boundaries
  - `experiment_8.py` — Phase 3: real urban domain
  - `experiment_8_imp_samp.py` — Phase 3: importance sampling variant

## Test plan
- [x] All experiment scripts now have descriptive module docstrings

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)