### PR TITLE
Tune experiment 1 min_depth and loss weights

### DIFF
--- a/configs/experiment_1.yaml
+++ b/configs/experiment_1.yaml
@@ -14,7 +14,7 @@ device:
   early_stop_patience: 3000
 numerics:
   eps: 1.0e-06
-  min_depth: 0.005
+  min_depth: 0.05
 plotting:
   nx_val: 101
   plot_resolution: 150

--- a/configs/train/experiment_1_mlp_final.yaml
+++ b/configs/train/experiment_1_mlp_final.yaml
@@ -14,7 +14,7 @@ device:
   early_stop_patience: 3000
 numerics:
   eps: 1.0e-06
-  min_depth: 0.005
+  min_depth: 0.0
 plotting:
   nx_val: 101
   plot_resolution: 150
@@ -46,11 +46,11 @@ sampling:
   n_points_ic: 1857
   n_points_bc_domain: 22000
 loss_weights:
-  pde_weight: 414759.9286194015
-  ic_weight: 1.0
-  bc_weight: 431.6350485748533
-  neg_h_weight: 1.0
-  data_weight: 10.0
+  pde_weight: 1.0
+  ic_weight: 0.000002409
+  bc_weight: 0.001038074
+  neg_h_weight: 0.000002409
+  data_weight: 0.0
 gradnorm:
   enable: false
 data_free: true


### PR DESCRIPTION
## Summary
- Adjust `min_depth` threshold: `0.005` → `0.05` (base config), `0.005` → `0.0` (MLP final)
- Normalise HPO-derived loss weights in MLP final config relative to `pde_weight=1.0` instead of raw Optuna values

## Test plan
- [ ] Verify configs parse correctly via `load_config()`
- [ ] Run 200-epoch smoke test with updated configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)