### PR TITLE
Fix accumulation_factor by passing num_batches to optimizer

### DIFF
--- a/experiments/experiment_1/train.py
+++ b/experiments/experiment_1/train.py
@@ -99,10 +99,6 @@ def main(config_path: str):
 
     print("Info: Running in analytical (no-building) mode.")
 
-    # --- 3. Setup Optimizer ---
-    optimiser = create_optimizer(cfg)
-    opt_state = optimiser.init(params)
-
     # --- 4. Prepare Loss Weights ---
     static_weights_dict, _ = extract_loss_weights(cfg)
     
@@ -248,6 +244,10 @@ def main(config_path: str):
     if num_batches == 0:
         print(f"Error: Batch size {batch_size} is too large for configured sample counts or data. No training will occur.")
         return -1.0
+
+    # --- 3. Setup Optimizer (after num_batches is known for accumulation_factor) ---
+    optimiser = create_optimizer(cfg, num_batches=num_batches)
+    opt_state = optimiser.init(params)
 
     # --- Define JIT Data Generator ---
     def generate_epoch_data(key):

--- a/experiments/experiment_2/train.py
+++ b/experiments/experiment_2/train.py
@@ -128,11 +128,6 @@ def main(config_path: str):
     print("Info: Running in building mode.")
     # --- END ASSERTION ---
 
-    # --- 3. Setup Optimizer ---
-    optimiser = create_optimizer(cfg)
-    opt_state = optimiser.init(params)
-
-
     # --- 4. Prepare Loss Weights ---
     static_weights_dict, _ = extract_loss_weights(cfg)
 
@@ -224,6 +219,9 @@ def main(config_path: str):
         return -1.0
     print(f"Calculated number of batches per epoch: {num_batches}")
 
+    # --- 3. Setup Optimizer (after num_batches is known for accumulation_factor) ---
+    optimiser = create_optimizer(cfg, num_batches=num_batches)
+    opt_state = optimiser.init(params)
 
     # --- Define JIT Data Generator ---
     def generate_epoch_data(key):


### PR DESCRIPTION
## Summary
- Move `create_optimizer()` call after `num_batches` is calculated in experiments 1 and 2
- Pass `num_batches=num_batches` so `accumulation_factor` in `reduce_on_plateau` correctly resolves to `num_batches * factor` (e.g., factor=1 = accumulate over 1 full epoch)
- Previously, experiments 1 and 2 called `create_optimizer(cfg)` without `num_batches`, so `accumulation_factor=1` meant accumulate over just 1 batch step instead of 1 epoch

## Test plan
- [ ] Run unit tests: `python -m unittest discover test` (35/35 pass)
- [ ] Verify LR reduction schedule with `accumulation_factor: 1` triggers per-epoch

🤖 Generated with [Claude Code](https://claude.com/claude-code)