### PR TITLE
Fix PRNG key reuse in HPO training loop

### DIFF
--- a/optimisation/optimization_train_loop.py
+++ b/optimisation/optimization_train_loop.py
@@ -398,8 +398,7 @@ def run_training_trial(trial: optuna.trial.Trial, trial_cfg: FrozenDict) -> floa
                         f"Time={epoch_time:.2f}s, Current Best NSE={best_nse_trial:.6f}")
 
 
-        # Update train_key for next epoch's sampling
-        train_key = key
+        # train_key is already advanced by random.split on line 356
 
 
     # --- 5. Return Final Objective Value ---


### PR DESCRIPTION
## Summary
- Removes line 402 in `optimisation/optimization_train_loop.py` which reset `train_key = key` at the end of every epoch, reverting to the original seed
- The `random.split(train_key)` on line 356 already correctly advances the PRNG chain — the reset was a bug causing every epoch to use identical collocation samples

## Test plan
- [ ] Verify HPO trials produce different collocation points across epochs (add a print of `epoch_key` for first 3 epochs to confirm they differ)
- [ ] Run a short HPO study (5 trials, 100 epochs) and confirm loss convergence behaviour changes (should converge better with diverse samples)

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)