### PR TITLE
Add missing FrozenDict import to experiment 7 and 8

### DIFF
--- a/experiments/experiment_7/train.py
+++ b/experiments/experiment_7/train.py
@@ -13,6 +13,7 @@ import pandas as pd
 import jax
 import jax.numpy as jnp
 from jax import random
+from flax.core import FrozenDict
 import numpy as np
 import matplotlib.pyplot as plt
 

--- a/experiments/experiment_8/train.py
+++ b/experiments/experiment_8/train.py
@@ -13,6 +13,7 @@ import pandas as pd
 import jax
 import jax.numpy as jnp
 from jax import random
+from flax.core import FrozenDict
 import numpy as np
 import matplotlib
 matplotlib.use('Agg')


### PR DESCRIPTION
## Summary
- Adds `from flax.core import FrozenDict` to `experiments/experiment_7/train.py` and `experiments/experiment_8/train.py`
- Both scripts use `FrozenDict(cfg_dict)` but never imported it, causing a `NameError` crash at runtime

## Test plan
- [ ] `python -c "from experiments.experiment_7.train import main"` — no import error
- [ ] `python -c "from experiments.experiment_8.train import main"` — no import error

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)