### PR TITLE
Fix axis mismatch in experiment 6 left-wall boundary concat

### DIFF
--- a/experiments/experiment_6/train.py
+++ b/experiments/experiment_6/train.py
@@ -186,10 +186,13 @@ def main(config_path: str):
         y_inflow_start = inflow_segment["y_start"]
         y_inflow_end = inflow_segment["y_end"]
 
-        l_in_key, l_wall_key, r_key, b_key, t_key = random.split(bc_keys, 5)
+        l_in_key, l_wall_bot_key, l_wall_top_key, r_key, b_key, t_key = random.split(bc_keys, 6)
         bc_inflow = sample_and_batch(l_in_key, sample_lhs, n_bc_inflow, batch_size, num_batches, (0., 0.), (y_inflow_start, y_inflow_end), t_range)
-        bc_left_wall_bottom = sample_and_batch(l_wall_key, sample_lhs, n_bc_per_wall, batch_size, num_batches, (0., 0.), (0., y_inflow_start), t_range)
-        bc_left_wall_above = sample_and_batch(l_wall_key, sample_lhs, n_bc_per_wall, batch_size, num_batches, (0., 0.), (y_inflow_end, domain_cfg["ly"]), t_range)
+        # Sample each left-wall sub-segment with half the batch size so the
+        # concatenated result has batch_size rows, matching the other walls.
+        n_bc_left_half = max(batch_size // 2, n_bc_per_wall // 2)
+        bc_left_wall_bottom = sample_and_batch(l_wall_bot_key, sample_lhs, n_bc_left_half, batch_size // 2, num_batches, (0., 0.), (0., y_inflow_start), t_range)
+        bc_left_wall_above = sample_and_batch(l_wall_top_key, sample_lhs, n_bc_left_half, batch_size // 2, num_batches, (0., 0.), (y_inflow_end, domain_cfg["ly"]), t_range)
         bc_left_wall = jnp.concatenate([bc_left_wall_bottom, bc_left_wall_above], axis=1)
         bc_right = sample_and_batch(r_key, sample_lhs, n_bc_per_wall, batch_size, num_batches, (domain_cfg["lx"], domain_cfg["lx"]), y_range, t_range)
         bc_bot = sample_and_batch(b_key, sample_lhs, n_bc_per_wall, batch_size, num_batches, x_range, (0., 0.), t_range)


### PR DESCRIPTION
## Summary
- Left wall BC was split into two sub-segments (below/above inflow), each sampled with full `batch_size`. Concatenating along `axis=1` produced `(num_batches, 2*batch_size, 3)` — double the expected size vs other walls
- Fix: sample each sub-segment with `batch_size // 2` so the concatenated result matches `batch_size`
- Also uses separate PRNG keys for each sub-segment instead of reusing the same key

## Test plan
- [ ] Print shapes of all BC batches in `generate_epoch_data` to confirm `bc_left_wall` matches `bc_right`, `bc_top`, `bc_bottom`
- [ ] Run experiment 6 for 200 epochs to verify no shape errors in `lax.scan`

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)