### PR TITLE
Bind loop variables in HPO lambda closure

### DIFF
--- a/optimisation/objective_function.py
+++ b/optimisation/objective_function.py
@@ -119,7 +119,7 @@ def objective(trial: optuna.trial.Trial, base_config_dict: Dict) -> float:
         
         min_w, max_w = (1.0, 1e6) if w == "pde_weight" else (1e-2, 1e3)
         trial_params["loss_weights"][w] = suggest(w, weights_cfg,
-            lambda: trial.suggest_float(w, min_w, max_w, log=True))
+            lambda w=w, min_w=min_w, max_w=max_w: trial.suggest_float(w, min_w, max_w, log=True))
 
     trial_params["loss_weights"]["data_weight"] = 0.0
 


### PR DESCRIPTION
## Summary
- Lambda inside the `loss_weights` loop in `objective_function.py` captured `w`, `min_w`, `max_w` by reference — all iterations would use the final loop values if the lambda were ever called lazily
- Fixed by binding via default arguments: `lambda w=w, min_w=min_w, max_w=max_w: ...`

## Test plan
- [x] All 35 unit tests pass
- [ ] Run HPO trial to verify weight suggestions use correct per-weight ranges

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)