### PR TITLE
Replace copy.deepcopy on JAX params with jax.tree.map

### DIFF
--- a/experiments/experiment_8/train_imp_samp.py
+++ b/experiments/experiment_8/train_imp_samp.py
@@ -8,7 +8,6 @@ Builds on: Experiment 8.
 import os
 import sys
 import time
-import copy
 import argparse
 import importlib
 import itertools
@@ -639,14 +638,14 @@ def main(config_path: str):
                     'total_weighted_loss': avg_total_weighted_loss,
                     'unweighted_losses': {k: float(v) for k, v in avg_losses_unweighted.items()}
                 })
-                best_params_nse = copy.deepcopy(params)
+                best_params_nse = jax.tree.map(jnp.copy, params)
                 if combined_nse_val > -jnp.inf:
                     print(f"    ---> New Best Combined NSE: {combined_nse_val:.4f}")
 
             if avg_total_weighted_loss < best_loss_stats['total_weighted_loss']:
                 best_loss_stats['total_weighted_loss'] = avg_total_weighted_loss
                 best_loss_stats['epoch'] = epoch
-                best_params_loss = copy.deepcopy(params)
+                best_params_loss = jax.tree.map(jnp.copy, params)
 
             # Negative depth diagnostics and checkpoint tracking
             freq = cfg.get("reporting", {}).get("epoch_freq", 100)

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -1,9 +1,9 @@
 """Shared training-loop body and post-training routines."""
 import os
-import copy
 import time
 import shutil
 
+import jax
 import jax.numpy as jnp
 from jax import lax
 
@@ -162,7 +162,7 @@ def run_training_loop(
                     'unweighted_losses': {k: float(v) for k, v in avg_losses_unweighted.items()},
                     'validation_metrics': dict(val_metrics),
                 })
-                best_params_nse = copy.deepcopy(params)
+                best_params_nse = jax.tree.map(jnp.copy, params)
 
             if avg_total_weighted_loss < best_loss_stats['total_weighted_loss']:
                 best_loss_stats.update({
@@ -172,7 +172,7 @@ def run_training_loop(
                     'unweighted_losses': {k: float(v) for k, v in avg_losses_unweighted.items()},
                     'validation_metrics': dict(val_metrics),
                 })
-                best_params_loss = copy.deepcopy(params)
+                best_params_loss = jax.tree.map(jnp.copy, params)
 
             freq = cfg.get("reporting", {}).get("epoch_freq", 100)
             epoch_time = time.time() - epoch_start_time


### PR DESCRIPTION
## Summary
- Replaced `copy.deepcopy(params)` with `jax.tree.map(jnp.copy, params)` in `src/training/loop.py` and `experiments/experiment_8/train_imp_samp.py`
- `copy.deepcopy` on JAX arrays copies device memory to host, duplicates, and copies back, adding 10-50ms per checkpoint update for large models (512-wide, 6-deep). `jax.tree.map(jnp.copy, params)` performs an efficient on-device copy instead.
- Removed unused `import copy` from both files
- Left `copy.deepcopy` calls on plain Python dicts (`optimisation/objective_function.py`, `src/monitoring/aim_tracker.py`) unchanged, as those are not JAX arrays

Closes #59

## Test plan
- [x] `python -m unittest discover test` passes (17/17 non-pre-existing tests pass; 15 pre-existing import errors from missing `src.data.paths` module unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)