### PR TITLE
Remove dead assignment and add eps validation in SWE physics

### DIFF
--- a/src/physics/swe.py
+++ b/src/physics/swe.py
@@ -6,6 +6,8 @@ from typing import Tuple
 class SWEPhysics:
     """Compute terms for the 2D Shallow Water Equations (SWE)."""
     def __init__(self, U: jnp.ndarray, eps: float, bed_elevation: jnp.ndarray = None):
+        if eps <= 0:
+            raise ValueError(f"eps must be positive, got {eps}")
         h = U[..., 0]
         self.hu = U[..., 1]
         self.hv = U[..., 2]
@@ -34,7 +36,6 @@ class SWEPhysics:
         vel = jnp.sqrt(self.u**2 + self.v**2)
         sfx = n_manning**2 * self.u * vel / (self.h_safe**(4 / 3))
         sfy = n_manning**2 * self.v * vel / (self.h_safe**(4 / 3))
-        sox = soy = 0.0
         sox = -bed_grad_x if bed_grad_x is not None else 0.0
         soy = -bed_grad_y if bed_grad_y is not None else 0.0
 


### PR DESCRIPTION
## Summary
- Removed redundant `sox = soy = 0.0` dead assignment in `SWEPhysics.source()` that was immediately overwritten on the next two lines
- Added `eps > 0` validation in `SWEPhysics.__init__()` to prevent silent division-by-zero when computing safe water depth

Closes #55

## Test plan
- [x] All 35 unit tests pass (`python -m unittest discover test`)
- [x] No behaviour change for valid inputs (eps is always positive in configs)
- [x] Constructor now raises `ValueError` for non-positive eps values

🤖 Generated with [Claude Code](https://claude.com/claude-code)