### PR TITLE
Deduplicate sanitize_for_yaml and study storage setup

### DIFF
--- a/optimisation/run_optimization.py
+++ b/optimisation/run_optimization.py
@@ -11,8 +11,6 @@ from functools import partial
 import time
 import yaml
 from flax.core import unfreeze, FrozenDict
-import numpy as np
-import jax.numpy as jnp
 
 # --- Add project root to path ---
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
@@ -21,6 +19,7 @@ if project_root not in sys.path:
 
 try:
     from optimisation.objective_function import objective
+    from optimisation.utils import sanitize_for_yaml, setup_study_storage
     from src.config import load_config
 except ImportError as e:
     print("Error: Could not import necessary modules.")
@@ -61,21 +60,7 @@ def main():
     base_config_dict["training"]["epochs"] = opt_epochs
 
     # --- Setup Optuna Study ---
-    if args.storage is None:
-        db_dir = os.path.join(project_root, "optimisation", "database")
-        os.makedirs(db_dir, exist_ok=True)
-        db_file = os.path.join(db_dir, "all_my_studies.db")
-        storage_path = f"sqlite:///{db_file}"
-    else:
-        storage_path = args.storage
-        if storage_path.startswith("sqlite:///"):
-            db_file = storage_path.split("sqlite:///")[-1]
-            if not os.path.isabs(db_file):
-                db_file = os.path.join(project_root, db_file)
-                storage_path = f"sqlite:///{db_file}"
-            db_dir = os.path.dirname(db_file)
-            if db_dir and not os.path.exists(db_dir):
-                os.makedirs(db_dir, exist_ok=True)
+    storage_path = setup_study_storage(args.storage, project_root)
 
     study = optuna.create_study(
         study_name=args.study_name,
@@ -129,13 +114,6 @@ def main():
             
             if 'full_config' in best_trial.user_attrs:
                 best_trial_config_dict = best_trial.user_attrs['full_config']
-
-                def sanitize_for_yaml(data):
-                    if isinstance(data, (jnp.ndarray, np.ndarray)): return data.tolist()
-                    if isinstance(data, (jnp.float32, jnp.float64, np.float32, np.float64)): return float(data)
-                    if isinstance(data, dict): return {k: sanitize_for_yaml(v) for k, v in data.items()}
-                    if isinstance(data, list): return [sanitize_for_yaml(item) for item in data]
-                    return data
 
                 if isinstance(best_trial_config_dict, FrozenDict):
                      best_trial_config_dict = unfreeze(best_trial_config_dict)

--- a/optimisation/run_sensitivity_analysis.py
+++ b/optimisation/run_sensitivity_analysis.py
@@ -13,8 +13,6 @@ from functools import partial
 import time
 import yaml
 from flax.core import unfreeze, FrozenDict
-import numpy as np
-import jax.numpy as jnp
 
 project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
 if project_root not in sys.path:
@@ -22,6 +20,7 @@ if project_root not in sys.path:
 
 try:
     from optimisation.objective_function import objective
+    from optimisation.utils import sanitize_for_yaml, setup_study_storage
     from src.config import load_config
 except ImportError as e:
     print("Error: Could not import necessary modules.")
@@ -59,21 +58,7 @@ def main():
     base_config_dict["training"]["epochs"] = opt_epochs
 
     # --- Setup Optuna Study ---
-    if args.storage is None:
-        db_dir = os.path.join(project_root, "optimisation", "database")
-        os.makedirs(db_dir, exist_ok=True)
-        db_file = os.path.join(db_dir, "all_my_studies.db")
-        storage_path = f"sqlite:///{db_file}"
-    else:
-        storage_path = args.storage
-        if storage_path.startswith("sqlite:///"):
-            db_file = storage_path.split("sqlite:///")[-1]
-            if not os.path.isabs(db_file):
-                db_file = os.path.join(project_root, db_file)
-                storage_path = f"sqlite:///{db_file}"
-            db_dir = os.path.dirname(db_file)
-            if db_dir and not os.path.exists(db_dir):
-                os.makedirs(db_dir, exist_ok=True)
+    storage_path = setup_study_storage(args.storage, project_root)
 
     print("Using QMCSampler for uniform exploration (Sensitivity Analysis).")
     sampler = optuna.samplers.QMCSampler()
@@ -133,13 +118,6 @@ def main():
 
             if 'full_config' in best_trial.user_attrs:
                 best_trial_config_dict = best_trial.user_attrs['full_config']
-                
-                def sanitize_for_yaml(data):
-                    if isinstance(data, (jnp.ndarray, np.ndarray)): return data.tolist()
-                    if isinstance(data, (jnp.float32, jnp.float64, np.float32, np.float64)): return float(data)
-                    if isinstance(data, dict): return {k: sanitize_for_yaml(v) for k, v in data.items()}
-                    if isinstance(data, list): return [sanitize_for_yaml(item) for item in data]
-                    return data
                 
                 if isinstance(best_trial_config_dict, FrozenDict):
                      best_trial_config_dict = unfreeze(best_trial_config_dict)

--- a/optimisation/utils.py
+++ b/optimisation/utils.py
@@ -1,0 +1,53 @@
+# optimisation/utils.py
+"""Shared utility helpers for Optuna optimisation scripts."""
+import os
+
+import numpy as np
+import jax.numpy as jnp
+
+
+def sanitize_for_yaml(data):
+    """Recursively convert JAX/numpy types to plain Python for YAML serialisation."""
+    if isinstance(data, (jnp.ndarray, np.ndarray)):
+        return data.tolist()
+    if isinstance(data, (jnp.float32, jnp.float64, np.float32, np.float64)):
+        return float(data)
+    if isinstance(data, dict):
+        return {k: sanitize_for_yaml(v) for k, v in data.items()}
+    if isinstance(data, list):
+        return [sanitize_for_yaml(item) for item in data]
+    return data
+
+
+def setup_study_storage(args_storage, project_root):
+    """Resolve the Optuna storage URL, creating the database directory if needed.
+
+    Parameters
+    ----------
+    args_storage : str or None
+        The ``--storage`` CLI argument.  When *None*, a default SQLite path
+        under ``optimisation/database/`` is used.
+    project_root : str
+        Absolute path to the repository root.
+
+    Returns
+    -------
+    str
+        A ``sqlite:///`` storage URL suitable for ``optuna.create_study``.
+    """
+    if args_storage is None:
+        db_dir = os.path.join(project_root, "optimisation", "database")
+        os.makedirs(db_dir, exist_ok=True)
+        db_file = os.path.join(db_dir, "all_my_studies.db")
+        return f"sqlite:///{db_file}"
+
+    storage_path = args_storage
+    if storage_path.startswith("sqlite:///"):
+        db_file = storage_path.split("sqlite:///")[-1]
+        if not os.path.isabs(db_file):
+            db_file = os.path.join(project_root, db_file)
+            storage_path = f"sqlite:///{db_file}"
+        db_dir = os.path.dirname(db_file)
+        if db_dir and not os.path.exists(db_dir):
+            os.makedirs(db_dir, exist_ok=True)
+    return storage_path


### PR DESCRIPTION
## Summary
- Extracted identical `sanitize_for_yaml()` from `run_optimization.py` and `run_sensitivity_analysis.py` into new `optimisation/utils.py` module
- Extracted duplicated Optuna study storage setup logic into `setup_study_storage()` helper in the same module
- Removed now-unused `numpy` and `jax.numpy` imports from both scripts

Closes #58

## Test plan
- [x] All 35 unit tests pass (`python -m unittest discover test`)
- [ ] Verify `run_optimization.py` still runs correctly with an HPO config
- [ ] Verify `run_sensitivity_analysis.py` still runs correctly with an exploration config

🤖 Generated with [Claude Code](https://claude.com/claude-code)