### PR TITLE
Log all physics losses at final checkpoint even when weights are 0.0

### DIFF
--- a/experiments/experiment_1/train.py
+++ b/experiments/experiment_1/train.py
@@ -314,6 +314,28 @@ def main(config_path: str):
             metrics = {'nse_h': float(nse_val), 'rmse_h': float(rmse_val)}
         return metrics
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 5)
+        x_range = (0., domain_cfg["lx"])
+        y_range = (0., domain_cfg["ly"])
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': sample_domain(keys[0], n_eval, x_range, y_range, t_range),
+            'ic': sample_domain(keys[1], n_eval, x_range, y_range, (0., 0.)),
+            'bc': {
+                'left': sample_domain(keys[2], n_eval, (0., 0.), y_range, t_range),
+                'right': sample_domain(keys[2], n_eval, (domain_cfg["lx"], domain_cfg["lx"]), y_range, t_range),
+                'bottom': sample_domain(keys[3], n_eval, x_range, (0., 0.), t_range),
+                'top': sample_domain(keys[3], n_eval, x_range, (domain_cfg["ly"], domain_cfg["ly"]), t_range),
+            },
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+            'building_bc': {},
+        }
+        return compute_losses(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -332,6 +354,7 @@ def main(config_path: str):
         config_path=config_path,
         validation_fn=validation_fn,
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_2/train.py
+++ b/experiments/experiment_2/train.py
@@ -292,6 +292,36 @@ def main(config_path: str):
             metrics = {'nse_h': float(nse_val), 'rmse_h': float(rmse_val)}
         return metrics
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 6)
+        x_range = (0., domain_cfg["lx"])
+        y_range = (0., domain_cfg["ly"])
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': sample_domain(keys[0], n_eval, x_range, y_range, t_range),
+            'ic': sample_domain(keys[1], n_eval, x_range, y_range, (0., 0.)),
+            'bc': {
+                'left': sample_domain(keys[2], n_eval, (0., 0.), y_range, t_range),
+                'right': sample_domain(keys[2], n_eval, (domain_cfg["lx"], domain_cfg["lx"]), y_range, t_range),
+                'bottom': sample_domain(keys[3], n_eval, x_range, (0., 0.), t_range),
+                'top': sample_domain(keys[3], n_eval, x_range, (domain_cfg["ly"], domain_cfg["ly"]), t_range),
+            },
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+            'building_bc': {},
+        }
+        if has_building:
+            b_cfg = cfg["building"]
+            batch['building_bc'] = {
+                'left': sample_domain(keys[4], n_eval, (b_cfg["x_min"], b_cfg["x_min"]), (b_cfg["y_min"], b_cfg["y_max"]), t_range),
+                'right': sample_domain(keys[4], n_eval, (b_cfg["x_max"], b_cfg["x_max"]), (b_cfg["y_min"], b_cfg["y_max"]), t_range),
+                'bottom': sample_domain(keys[5], n_eval, (b_cfg["x_min"], b_cfg["x_max"]), (b_cfg["y_min"], b_cfg["y_min"]), t_range),
+                'top': sample_domain(keys[5], n_eval, (b_cfg["x_min"], b_cfg["x_max"]), (b_cfg["y_max"], b_cfg["y_max"]), t_range),
+            }
+        return compute_losses(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -310,6 +340,7 @@ def main(config_path: str):
         config_path=config_path,
         validation_fn=validation_fn,
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_3/train.py
+++ b/experiments/experiment_3/train.py
@@ -222,6 +222,25 @@ def main(config_path: str):
         cfg, data_free, compute_losses_fn=compute_losses_fn,
     )
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 5)
+        x_range = (0., domain_cfg["lx"])
+        y_range = (0., domain_cfg["ly"])
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': sample_lhs(keys[0], n_eval, x_range, y_range, t_range),
+            'ic': sample_lhs(keys[1], n_eval, x_range, y_range, (0., 0.)),
+            'bc_left': sample_lhs(keys[2], n_eval, (0., 0.), y_range, t_range),
+            'bc_right': sample_lhs(keys[2], n_eval, (domain_cfg["lx"], domain_cfg["lx"]), y_range, t_range),
+            'bc_bottom': sample_lhs(keys[3], n_eval, x_range, (0., 0.), t_range),
+            'bc_top': sample_lhs(keys[3], n_eval, x_range, (domain_cfg["ly"], domain_cfg["ly"]), t_range),
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+        }
+        return compute_losses_fn(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -243,6 +262,7 @@ def main(config_path: str):
         h_true_val_all=h_true_val_all,
         val_targets_all=val_targets_all,
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_4/train.py
+++ b/experiments/experiment_4/train.py
@@ -227,6 +227,27 @@ def main(config_path: str):
         cfg, data_free, compute_losses_fn=compute_losses_fn,
     )
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    inflow_segment = cfg["boundary_conditions"]["left_inflow_segment"]
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 6)
+        x_range = (0., domain_cfg["lx"])
+        y_range = (0., domain_cfg["ly"])
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': sample_lhs(keys[0], n_eval, x_range, y_range, t_range),
+            'ic': sample_lhs(keys[1], n_eval, x_range, y_range, (0., 0.)),
+            'bc_inflow': sample_lhs(keys[2], n_eval, (0., 0.), (inflow_segment["y_start"], inflow_segment["y_end"]), t_range),
+            'bc_left_wall': sample_lhs(keys[3], n_eval, (0., 0.), (0., inflow_segment["y_start"]), t_range),
+            'bc_right': sample_lhs(keys[3], n_eval, (domain_cfg["lx"], domain_cfg["lx"]), y_range, t_range),
+            'bc_bottom': sample_lhs(keys[4], n_eval, x_range, (0., 0.), t_range),
+            'bc_top': sample_lhs(keys[4], n_eval, x_range, (domain_cfg["ly"], domain_cfg["ly"]), t_range),
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+        }
+        return compute_losses_fn(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -248,6 +269,7 @@ def main(config_path: str):
         h_true_val_all=h_true_val_all,
         val_targets_all=val_targets_all,
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_5/train.py
+++ b/experiments/experiment_5/train.py
@@ -215,6 +215,25 @@ def main(config_path: str):
         cfg, data_free, compute_losses_fn=compute_losses_fn,
     )
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 5)
+        x_range = (0., domain_cfg["lx"])
+        y_range = (0., domain_cfg["ly"])
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': sample_lhs(keys[0], n_eval, x_range, y_range, t_range),
+            'ic': sample_lhs(keys[1], n_eval, x_range, y_range, (0., 0.)),
+            'bc_left': sample_lhs(keys[2], n_eval, (0., 0.), y_range, t_range),
+            'bc_right': sample_lhs(keys[2], n_eval, (domain_cfg["lx"], domain_cfg["lx"]), y_range, t_range),
+            'bc_bottom': sample_lhs(keys[3], n_eval, x_range, (0., 0.), t_range),
+            'bc_top': sample_lhs(keys[3], n_eval, x_range, (domain_cfg["ly"], domain_cfg["ly"]), t_range),
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+        }
+        return compute_losses_fn(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -236,6 +255,7 @@ def main(config_path: str):
         h_true_val_all=h_true_val_all,
         val_targets_all=val_targets_all,
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_6/train.py
+++ b/experiments/experiment_6/train.py
@@ -223,6 +223,27 @@ def main(config_path: str):
         cfg, data_free, compute_losses_fn=compute_losses_fn,
     )
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    inflow_segment = cfg["boundary_conditions"]["left_inflow_segment"]
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 6)
+        x_range = (0., domain_cfg["lx"])
+        y_range = (0., domain_cfg["ly"])
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': sample_lhs(keys[0], n_eval, x_range, y_range, t_range),
+            'ic': sample_lhs(keys[1], n_eval, x_range, y_range, (0., 0.)),
+            'bc_inflow': sample_lhs(keys[2], n_eval, (0., 0.), (inflow_segment["y_start"], inflow_segment["y_end"]), t_range),
+            'bc_left_wall': sample_lhs(keys[3], n_eval, (0., 0.), (0., inflow_segment["y_start"]), t_range),
+            'bc_right': sample_lhs(keys[3], n_eval, (domain_cfg["lx"], domain_cfg["lx"]), y_range, t_range),
+            'bc_bottom': sample_lhs(keys[4], n_eval, x_range, (0., 0.), t_range),
+            'bc_top': sample_lhs(keys[4], n_eval, x_range, (domain_cfg["ly"], domain_cfg["ly"]), t_range),
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+        }
+        return compute_losses_fn(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -244,6 +265,7 @@ def main(config_path: str):
         h_true_val_all=h_true_val_all,
         val_targets_all=val_targets_all,
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_7/train.py
+++ b/experiments/experiment_7/train.py
@@ -238,6 +238,21 @@ def main(config_path: str):
         cfg, data_free, compute_losses_fn=compute_losses_fn,
     )
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 5)
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': domain_sampler.sample_interior(keys[0], n_eval, t_range),
+            'ic': domain_sampler.sample_interior(keys[1], n_eval, (0., 0.)),
+            'bc_inflow': domain_sampler.sample_boundary(keys[2], n_eval, t_range, 'inflow'),
+            'bc_wall': domain_sampler.sample_boundary(keys[3], n_eval, t_range, 'wall'),
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+        }
+        return compute_losses_fn(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -259,6 +274,7 @@ def main(config_path: str):
         h_true_val_all=h_true_val_all,
         val_targets_all=val_targets_all,
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_8/train.py
+++ b/experiments/experiment_8/train.py
@@ -291,6 +291,22 @@ def main(config_path: str):
             'rmse_hv': float(rmse_hv_val),
         }
 
+    # --- Evaluate All Physics Losses (including zero-weight terms) ---
+    n_eval = 200
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 6)
+        t_range = (0., domain_cfg["t_final"])
+        batch = {
+            'pde': domain_sampler.sample_interior(keys[0], n_eval, t_range),
+            'ic': domain_sampler.sample_interior(keys[1], n_eval, (0., 0.)),
+            'bc_upstream': domain_sampler.sample_boundary(keys[2], n_eval, t_range, 'upstream'),
+            'bc_wall': domain_sampler.sample_boundary(keys[3], n_eval, t_range, 'wall'),
+            'bc_building': domain_sampler.sample_boundary(keys[4], n_eval, t_range, 'building'),
+            'data': jnp.empty((0, 6), dtype=DTYPE),
+        }
+        return compute_losses_fn(model, params, batch, cfg, data_free=True)
+
     loop_result = run_training_loop(
         cfg=cfg,
         cfg_dict=cfg_dict,
@@ -311,6 +327,7 @@ def main(config_path: str):
         validation_fn=validation_fn,
         selection_metric_key="selection_metric",
         source_script_path=__file__,
+        compute_all_losses_fn=compute_all_losses_fn,
     )
 
     def plot_fn(final_params):

--- a/experiments/experiment_8/train_imp_samp.py
+++ b/experiments/experiment_8/train_imp_samp.py
@@ -706,7 +706,37 @@ def main(config_path: str):
     finally:
         total_time = time.time() - start_time
 
-        ckpt_mgr.save_final(epoch if 'epoch' in locals() else 0, params, opt_state, val_metrics, avg_losses_unweighted, avg_total_weighted_loss, cfg_dict, neg_depth)
+        # Evaluate all physics losses on best-NSE params (even zero-weight terms)
+        all_physics_losses = {}
+        eval_params = best_params_nse if best_params_nse is not None else params
+        try:
+            eval_key = random.PRNGKey(0)
+            eval_keys = random.split(eval_key, 6)
+            n_eval = 200
+            t_range = (0., domain_cfg["t_final"])
+            eval_batch = {
+                'pde': domain_sampler.sample_interior(eval_keys[0], n_eval, t_range),
+                'ic': domain_sampler.sample_interior(eval_keys[1], n_eval, (0., 0.)),
+                'bc_upstream': domain_sampler.sample_boundary(eval_keys[2], n_eval, t_range, 'upstream'),
+                'bc_wall': domain_sampler.sample_boundary(eval_keys[3], n_eval, t_range, 'wall'),
+                'bc_building': domain_sampler.sample_boundary(eval_keys[4], n_eval, t_range, 'building'),
+                'data': jnp.empty((0, 6), dtype=DTYPE),
+            }
+            all_physics_losses = compute_losses_fn(model, eval_params, eval_batch, cfg, data_free=True)
+            all_physics_losses = {k: float(v) for k, v in all_physics_losses.items()}
+            print(f"\nAll physics losses (best-NSE params):")
+            for k, v in all_physics_losses.items():
+                print(f"  {k}: {v:.6e}")
+        except Exception as e:
+            print(f"Warning: Failed to evaluate all physics losses: {e}")
+
+        # Merge all_physics_losses into final losses for the checkpoint
+        final_losses_for_ckpt = dict(avg_losses_unweighted)
+        for k, v in all_physics_losses.items():
+            if k not in final_losses_for_ckpt:
+                final_losses_for_ckpt[k] = v
+
+        ckpt_mgr.save_final(epoch if 'epoch' in locals() else 0, params, opt_state, val_metrics, final_losses_for_ckpt, avg_total_weighted_loss, cfg_dict, neg_depth)
 
         best_nse_ckpt = ckpt_mgr.get_best_nse_stats()
         best_loss_ckpt = ckpt_mgr.get_best_loss_stats()
@@ -716,7 +746,7 @@ def main(config_path: str):
             final_epoch=epoch if 'epoch' in locals() else 0,
             best_nse_stats=best_nse_ckpt,
             best_loss_stats=best_loss_ckpt,
-            final_losses=avg_losses_unweighted,
+            final_losses=final_losses_for_ckpt,
             final_val_metrics=val_metrics,
             neg_depth_final=neg_depth,
             neg_depth_best_nse={},
@@ -726,7 +756,7 @@ def main(config_path: str):
 
         final_params = best_params_loss if best_params_loss is not None else best_params_nse
 
-        aim_tracker.log_summary({
+        summary_metrics = {
             'best_validation_model': best_nse_stats,
             'best_loss_model': best_loss_stats,
             'final_system': {
@@ -734,7 +764,10 @@ def main(config_path: str):
                 'total_epochs_run': (epoch + 1) if 'epoch' in locals() else 0,
                 'total_steps_run': global_step
             }
-        })
+        }
+        if all_physics_losses:
+            summary_metrics['all_physics_losses'] = all_physics_losses
+        aim_tracker.log_summary(summary_metrics)
 
         if ask_for_confirmation():
             if final_params is not None:

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -43,6 +43,7 @@ def run_training_loop(
     validation_fn=None,
     selection_metric_key="nse_h",
     source_script_path=None,
+    compute_all_losses_fn=None,
 ):
     """Execute the full epoch loop with logging, checkpointing, and early stopping.
 
@@ -57,6 +58,12 @@ def run_training_loop(
     pde_key_for_diag : str
         Key in the scan_inputs pytree where PDE points live (for negative-depth
         diagnostics).  Typically ``"pde"``.
+    compute_all_losses_fn : callable, optional
+        ``(model, params) -> dict[str, float]`` — evaluates **all** physics
+        loss terms (PDE, IC, BC, neg_h, etc.) regardless of whether their
+        training weights were zero.  Called once at the end of training on the
+        best-NSE parameters so that physics compliance is always recorded in
+        the final checkpoint metadata and summary.
 
     Returns
     -------
@@ -230,8 +237,28 @@ def run_training_loop(
 
     finally:
         total_time = time.time() - start_time
+
+        # Evaluate all physics losses on best-NSE params (even zero-weight terms)
+        all_physics_losses = {}
+        if compute_all_losses_fn is not None:
+            eval_params = best_params_nse if best_params_nse is not None else params
+            try:
+                all_physics_losses = compute_all_losses_fn(model, eval_params)
+                all_physics_losses = {k: float(v) for k, v in all_physics_losses.items()}
+                print(f"\nAll physics losses (best-NSE params):")
+                for k, v in all_physics_losses.items():
+                    print(f"  {k}: {v:.6e}")
+            except Exception as e:
+                print(f"Warning: Failed to evaluate all physics losses: {e}")
+
+        # Merge all_physics_losses into final losses for the checkpoint
+        final_losses_for_ckpt = dict(avg_losses_unweighted)
+        for k, v in all_physics_losses.items():
+            if k not in final_losses_for_ckpt:
+                final_losses_for_ckpt[k] = v
+
         ckpt_mgr.save_final(epoch, params, opt_state, val_metrics,
-                            avg_losses_unweighted, avg_total_weighted_loss, cfg_dict, neg_depth)
+                            final_losses_for_ckpt, avg_total_weighted_loss, cfg_dict, neg_depth)
         best_nse_ckpt = ckpt_mgr.get_best_nse_stats()
         best_loss_ckpt = ckpt_mgr.get_best_loss_stats()
 
@@ -240,7 +267,7 @@ def run_training_loop(
             final_epoch=epoch,
             best_nse_stats=best_nse_ckpt,
             best_loss_stats=best_loss_ckpt,
-            final_losses=avg_losses_unweighted,
+            final_losses=final_losses_for_ckpt,
             final_val_metrics=val_metrics,
             neg_depth_final=neg_depth,
             neg_depth_best_nse={},
@@ -259,6 +286,8 @@ def run_training_loop(
                         'total_steps_run': global_step,
                     }
                 }
+                if all_physics_losses:
+                    summary_metrics['all_physics_losses'] = all_physics_losses
                 aim_tracker.log_summary(summary_metrics)
                 print("Summary metrics logged to Aim.")
             except Exception as e:


### PR DESCRIPTION
## Summary
- Add `compute_all_losses_fn` callback to `run_training_loop` that evaluates **all** physics loss terms (PDE, IC, BC, neg_h) on the best-NSE model parameters after training, regardless of whether their weights were zero during training
- Each experiment script (1-8, including importance sampling variant) provides this callback, sampling 200 evaluation points per term and calling the experiment-specific loss function
- Results are merged into the final checkpoint `metadata.yaml`, printed in the completion summary, and logged to Aim under `all_physics_losses`

## Test plan
- [x] Verified `git diff --stat` shows only changes related to issue #65 (10 files)
- [x] Confirmed all pre-existing passing tests (17/32) remain passing -- the 15 failures are pre-existing import errors due to a missing `src/data/paths.py` module unrelated to this change
- [x] The new parameter `compute_all_losses_fn` is optional (defaults to `None`), so existing callers are not affected
- [x] Loss evaluation is wrapped in try/except so failures do not crash the training loop

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)