### PR TITLE
Clarify accumulation_factor vs accumulation_size config semantics

### DIFF
--- a/configs/experiment_1.yaml
+++ b/configs/experiment_1.yaml
@@ -31,7 +31,7 @@ training:
     rtol: 1e-4                     # Relative tolerance for measuring new optimum
     atol: 0.0                      # Absolute tolerance for measuring new optimum
     cooldown: 1                  # Number of steps to wait before resuming normal operation after lr has been reduced
-    accumulation_factor: 1          # Number of steps to accumulate the metric (loss) before checking for plateau
+    accumulation_factor: 1          # Multiplier on num_batches: accumulation_size = num_batches * factor
     min_scale: 1e-4                # Minimum scaling factor allowed
 
 validation_grid:

--- a/configs/train/experiment_1_dgm_final.yaml
+++ b/configs/train/experiment_1_dgm_final.yaml
@@ -31,7 +31,7 @@ training:
     rtol: 1e-4                     # Relative tolerance for measuring new optimum
     atol: 0.0                      # Absolute tolerance for measuring new optimum
     cooldown: 1                  # Number of steps to wait before resuming normal operation after lr has been reduced
-    accumulation_size: 114          # Number of steps to accumulate the metric (loss) before checking for plateau
+    accumulation_size: 114          # Absolute step count (HPO-optimized); overrides accumulation_factor
     min_scale: 1e-4                # Minimum scaling factor allowed
 validation_grid:
   n_points_val: 45000

--- a/configs/train/experiment_1_fourier_final.yaml
+++ b/configs/train/experiment_1_fourier_final.yaml
@@ -31,7 +31,7 @@ training:
     rtol: 1e-4                     # Relative tolerance for measuring new optimum
     atol: 0.0                      # Absolute tolerance for measuring new optimum
     cooldown: 1                  # Number of steps to wait before resuming normal operation after lr has been reduced
-    accumulation_size: 320          # Number of steps to accumulate the metric (loss) before checking for plateau
+    accumulation_size: 320          # Absolute step count (HPO-optimized); overrides accumulation_factor
     min_scale: 1e-4                # Minimum scaling factor allowed
 validation_grid:
   n_points_val: 45000

--- a/configs/train/experiment_1_mlp_final.yaml
+++ b/configs/train/experiment_1_mlp_final.yaml
@@ -31,7 +31,7 @@ training:
     rtol: 1e-4                     # Relative tolerance for measuring new optimum
     atol: 0.0                      # Absolute tolerance for measuring new optimum
     cooldown: 1                  # Number of steps to wait before resuming normal operation after lr has been reduced
-    accumulation_size: 235          # Number of steps to accumulate the metric (loss) before checking for plateau
+    accumulation_size: 235          # Absolute step count (HPO-optimized); overrides accumulation_factor
     min_scale: 1e-4                # Minimum scaling factor allowed
 
 validation_grid:

--- a/configs/train/experiment_2_dgm_final.yaml
+++ b/configs/train/experiment_2_dgm_final.yaml
@@ -31,7 +31,7 @@ training:
     rtol: 1e-4                     # Relative tolerance for measuring new optimum
     atol: 0.0                      # Absolute tolerance for measuring new optimum
     cooldown: 1                  # Number of steps to wait before resuming normal operation after lr has been reduced
-    accumulation_size: 212          # Number of steps to accumulate the metric (loss) before checking for plateau
+    accumulation_size: 212          # Absolute step count (HPO-optimized); overrides accumulation_factor
     min_scale: 1e-4                # Minimum scaling factor allowed
 building:
   x_max: 375.0

--- a/configs/train/experiment_2_fourier_final.yaml
+++ b/configs/train/experiment_2_fourier_final.yaml
@@ -31,7 +31,7 @@ training:
     rtol: 1e-4                     # Relative tolerance for measuring new optimum
     atol: 0.0                      # Absolute tolerance for measuring new optimum
     cooldown: 1                  # Number of steps to wait before resuming normal operation after lr has been reduced
-    accumulation_size: 201          # Number of steps to accumulate the metric (loss) before checking for plateau
+    accumulation_size: 201          # Absolute step count (HPO-optimized); overrides accumulation_factor
     min_scale: 1e-4                # Minimum scaling factor allowed
 building:
   x_max: 375.0

--- a/src/training/optimizer.py
+++ b/src/training/optimizer.py
@@ -10,9 +10,9 @@ def create_optimizer(cfg, num_batches=None):
     cfg : FrozenDict
         Full experiment config.
     num_batches : int, optional
-        Batches per epoch.  Used for ``accumulation_size`` when
-        ``accumulation_factor`` is present in config instead of a fixed
-        ``accumulation_size``.
+        Batches per epoch.  Multiplied by ``accumulation_factor`` to get
+        the step count for reduce_on_plateau.  Ignored when the config
+        provides an absolute ``accumulation_size`` instead.
 
     Returns
     -------
@@ -20,7 +20,7 @@ def create_optimizer(cfg, num_batches=None):
     """
     rop_cfg = cfg.get("training", {}).get("reduce_on_plateau", {})
 
-    # Resolve accumulation_size: either explicit or num_batches * factor
+    # accumulation_size (absolute) takes priority; otherwise factor * num_batches
     if "accumulation_size" in rop_cfg:
         accum = int(rop_cfg["accumulation_size"])
     elif num_batches is not None:


### PR DESCRIPTION
## Summary
- **`accumulation_factor`** (base configs): multiplier on `num_batches` → `accumulation_size = num_batches * factor`
- **`accumulation_size`** (HPO final configs): absolute step count from Optuna, overrides factor
- Updated config comments to make the distinction clear
- Updated optimizer.py docstring
- No behavior change — code already supported both keys correctly

## Test plan
- [x] All 35 unit tests pass

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)