### PR TITLE
Remove dead grad_norm tracking code

### DIFF
--- a/experiments/experiment_8/train_imp_samp.py
+++ b/experiments/experiment_8/train_imp_samp.py
@@ -652,14 +652,14 @@ def main(config_path: str):
                 console.print_epoch(
                     epoch, cfg["training"]["epochs"],
                     avg_losses_unweighted, avg_total_weighted_loss,
-                    current_lr, 0.0,
+                    current_lr,
                     val_metrics, neg_depth.get('fraction', 0.0), epoch_time
                 )
 
             aim_tracker.log_epoch(
                 epoch=epoch, step=global_step,
                 losses=avg_losses_unweighted, total_loss=avg_total_weighted_loss,
-                val_metrics=val_metrics, lr=current_lr, grad_norm=0.0,
+                val_metrics=val_metrics, lr=current_lr,
                 epoch_time=epoch_time, elapsed_time=time.time() - start_time,
                 neg_depth=neg_depth if (epoch + 1) % freq == 0 else None,
             )

--- a/src/monitoring/aim_tracker.py
+++ b/src/monitoring/aim_tracker.py
@@ -90,7 +90,6 @@ class AimTracker:
         total_loss: float,
         val_metrics: Dict[str, float],
         lr: float,
-        grad_norm: float,
         epoch_time: float,
         elapsed_time: float,
         neg_depth: Optional[Dict[str, float]] = None,
@@ -121,11 +120,6 @@ class AimTracker:
                 _safe_float(lr), name='optim/lr',
                 step=step, epoch=epoch, context=ctx_train,
             )
-            if grad_norm is not None and grad_norm != 0.0:
-                run.track(
-                    _safe_float(grad_norm), name='optim/grad_norm',
-                    step=step, epoch=epoch, context=ctx_train,
-                )
             run.track(
                 _safe_float(epoch_time), name='optim/epoch_time_sec',
                 step=step, epoch=epoch, context=ctx_sys,

--- a/src/monitoring/console_logger.py
+++ b/src/monitoring/console_logger.py
@@ -96,7 +96,6 @@ class ConsoleLogger:
         losses: Dict[str, float],
         total_loss: float,
         lr: float,
-        grad_norm: float,
         val_metrics: Dict[str, float],
         neg_h_frac: float,
         epoch_time: float,
@@ -121,7 +120,6 @@ class ConsoleLogger:
             f"Epoch {epoch + 1:>6d}/{max_epochs} | "
             f"Loss: {total_loss:.6e} [{parts_str}] | "
             f"LR: {lr:.2e} | "
-            f"\u2207: {grad_norm:.2e} | "
             f"NSE(h): {nse_h:.4f} | "
             f"-h: {neg_h_frac:.1%} | "
             f"{epoch_time:.1f}s"

--- a/src/monitoring/diagnostics.py
+++ b/src/monitoring/diagnostics.py
@@ -1,6 +1,5 @@
-"""Training diagnostics: negative depth stats and gradient norms."""
+"""Training diagnostics: negative depth stats."""
 import jax.numpy as jnp
-import optax
 from typing import Dict
 
 
@@ -36,7 +35,3 @@ def compute_negative_depth_diagnostics(
         'mean': float(jnp.mean(neg_values)),
     }
 
-
-def compute_grad_norm(grads) -> float:
-    """Compute the global L2 norm of a gradient pytree."""
-    return float(optax.global_norm(grads))

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -208,14 +208,14 @@ def run_training_loop(
                 console.print_epoch(
                     epoch, cfg["training"]["epochs"],
                     avg_losses_unweighted, avg_total_weighted_loss,
-                    current_lr, 0.0,
+                    current_lr,
                     val_metrics, neg_depth.get('fraction', 0.0), epoch_time
                 )
 
             aim_tracker.log_epoch(
                 epoch=epoch, step=global_step,
                 losses=avg_losses_unweighted, total_loss=avg_total_weighted_loss,
-                val_metrics=val_metrics, lr=current_lr, grad_norm=0.0,
+                val_metrics=val_metrics, lr=current_lr,
                 epoch_time=epoch_time, elapsed_time=time.time() - start_time,
                 neg_depth=neg_depth if (epoch + 1) % freq == 0 else None,
             )


### PR DESCRIPTION
## Summary
- Remove `grad_norm` parameter from `AimTracker.log_epoch()` and `ConsoleLogger.print_epoch()`
- Remove `compute_grad_norm()` function and unused `optax` import from `diagnostics.py`
- Remove hardcoded `grad_norm=0.0` from all call sites in `loop.py` and `train_imp_samp.py`

`grad_norm` was hardcoded to `0.0` at every call site. The Aim tracker skipped logging when the value was `0.0`, so it was never actually recorded. Pure dead-code removal.

## Test plan
- [x] All 42 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)