### PR TITLE
fix: #100 + #101 aim_tracker cleanup

### DIFF
--- a/experiments/experiment_8/train_imp_samp.py
+++ b/experiments/experiment_8/train_imp_samp.py
@@ -642,10 +642,10 @@ def main(config_path: str):
                 event_type, value, ep, prev_value, prev_epoch = event
                 if event_type == 'best_nse':
                     console.print_checkpoint_nse(value, ep, prev_value, prev_epoch)
-                    aim_tracker.log_best_nse(value, ep)
+                    aim_tracker.log_best_nse(value, ep, step=global_step)
                 elif event_type == 'best_loss':
                     console.print_checkpoint_loss(value, ep, prev_value, prev_epoch)
-                    aim_tracker.log_best_loss(value, ep)
+                    aim_tracker.log_best_loss(value, ep, step=global_step)
 
             # --- Reporting ---
             if (epoch + 1) % freq == 0:

--- a/src/monitoring/aim_tracker.py
+++ b/src/monitoring/aim_tracker.py
@@ -93,7 +93,6 @@ class AimTracker:
         epoch_time: float,
         elapsed_time: float,
         neg_depth: Optional[Dict[str, float]] = None,
-        gradnorm_weights: Optional[Dict[str, float]] = None,
     ):
         if not self.enabled:
             return
@@ -146,40 +145,31 @@ class AimTracker:
                         step=step, epoch=epoch, context=ctx_diag,
                     )
 
-            # GradNorm weights
-            if gradnorm_weights:
-                for key, val in gradnorm_weights.items():
-                    run.track(
-                        _safe_float(val),
-                        name=f'gradnorm/weight_{key}',
-                        step=step, epoch=epoch, context=ctx_train,
-                    )
-
         except Exception as e:
             print(f"Warning: Aim logging failed at epoch {epoch}: {e}")
 
     # ------------------------------------------------------------------
     # Best-model tracking (E.4)
     # ------------------------------------------------------------------
-    def log_best_nse(self, nse_h: float, epoch: int):
+    def log_best_nse(self, nse_h: float, epoch: int, step: int):
         if not self.enabled:
             return
         try:
             self.aim_run.track(
                 _safe_float(nse_h), name='best/nse_h_value',
-                step=epoch, epoch=epoch,
+                step=step, epoch=epoch,
             )
             self.aim_run['best_nse_h_epoch'] = epoch + 1
         except Exception:
             pass
 
-    def log_best_loss(self, loss: float, epoch: int):
+    def log_best_loss(self, loss: float, epoch: int, step: int):
         if not self.enabled:
             return
         try:
             self.aim_run.track(
                 _safe_float(loss), name='best/loss_value',
-                step=epoch, epoch=epoch,
+                step=step, epoch=epoch,
             )
             self.aim_run['best_loss_epoch'] = epoch + 1
         except Exception:

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -199,10 +199,10 @@ def run_training_loop(
                 event_type, value, ep, prev_value, prev_epoch = event
                 if event_type == 'best_nse':
                     console.print_checkpoint_nse(value, ep, prev_value, prev_epoch)
-                    aim_tracker.log_best_nse(value, ep)
+                    aim_tracker.log_best_nse(value, ep, step=global_step)
                 elif event_type == 'best_loss':
                     console.print_checkpoint_loss(value, ep, prev_value, prev_epoch)
-                    aim_tracker.log_best_loss(value, ep)
+                    aim_tracker.log_best_loss(value, ep, step=global_step)
 
             if (epoch + 1) % freq == 0:
                 console.print_epoch(


### PR DESCRIPTION
Closes #100, closes #101

## Summary
- **#100**: `log_best_nse()` and `log_best_loss()` now accept a `step` parameter and record `global_step` instead of duplicating `epoch` into both Aim axes. Callers in `src/training/loop.py` and `experiments/experiment_8/train_imp_samp.py` updated.
- **#101**: Removed dead `gradnorm_weights` parameter and tracking block from `log_epoch()` — GradNorm was already removed in PR #112.

## Test plan
- [x] All 83 unit tests pass (`python -m unittest discover test`)
- [ ] Verify Aim UI shows correct global step on x-axis for `best/*` metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)