### PR TITLE
Add PDE Jacobian benchmarking script

### DIFF
--- a/scripts/benchmark_pde_jacobian.py
+++ b/scripts/benchmark_pde_jacobian.py
@@ -18,7 +18,6 @@ Benchmarks:
 import argparse
 import json
 import os
-import time
 import timeit
 
 import jax
@@ -26,7 +25,7 @@ import jax.numpy as jnp
 from jax import random
 from flax.core import FrozenDict
 
-from src.config import load_config, get_dtype, DTYPE
+from src.config import load_config, get_dtype
 from src.models.pinn import MLP, FourierPINN, DGMNetwork
 from src.models.factory import init_model
 
@@ -46,8 +45,9 @@ def benchmark_jacobian_batch_sizes(model, params, key, dtype, batch_sizes=None):
     U_fn = _make_U_fn(model, params)
     jac_fn = jax.jit(jax.vmap(jax.jacfwd(U_fn)))
 
-    # Warmup (JIT compile)
-    warmup_batch = jnp.ones((1, 3), dtype=dtype)
+    # Warmup with largest batch size so JAX compiles for the right shape
+    max_batch = max(batch_sizes)
+    warmup_batch = random.uniform(key, (max_batch, 3), dtype=dtype)
     _ = jac_fn(warmup_batch)
     jax.block_until_ready(_)
 


### PR DESCRIPTION
## Summary
- Adds `scripts/benchmark_pde_jacobian.py` to profile the primary training bottleneck
- Benchmarks Jacobian wall-clock time vs batch size (100–10k points)
- Compares `jacfwd` vs `jacrev` for the 3-input/3-output SWE model
- Profiles all three architectures (MLP, FourierPINN, DGM) at equal width/depth
- Breaks down loss component timing: PDE Jacobian, IC, BC, and backward pass through Jacobian

Closes #105

## Test plan
- [x] All 83 existing tests pass
- [ ] Run `python scripts/benchmark_pde_jacobian.py --config configs/experiment_1.yaml` on GPU
- [ ] Verify JSON report generation with `--output profiling/`
- [ ] Review per-architecture timing comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)