### PR TITLE
Remove deprecated config keys from HPO configs

### DIFF
--- a/optimisation/configs/exploitation/hpo_exploitation_dgm_building.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_dgm_building.yaml
@@ -1,4 +1,4 @@
-hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
+hpo_settings: {data_free: true, enable_gradnorm: false}
 scenario: experiment_2
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}

--- a/optimisation/configs/exploitation/hpo_exploitation_dgm_nobuilding.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_dgm_nobuilding.yaml
@@ -1,4 +1,4 @@
-hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
+hpo_settings: {data_free: true, enable_gradnorm: false}
 scenario: experiment_1
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}

--- a/optimisation/configs/exploitation/hpo_exploitation_fourier_building.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_fourier_building.yaml
@@ -1,4 +1,4 @@
-hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
+hpo_settings: {data_free: true, enable_gradnorm: false}
 scenario: experiment_2
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}

--- a/optimisation/configs/exploitation/hpo_exploitation_fourier_nobuilding.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_fourier_nobuilding.yaml
@@ -1,4 +1,4 @@
-hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
+hpo_settings: {data_free: true, enable_gradnorm: false}
 scenario: experiment_1
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}

--- a/optimisation/configs/exploitation/hpo_exploitation_mlp_building.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_mlp_building.yaml
@@ -1,4 +1,4 @@
-hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
+hpo_settings: {data_free: true, enable_gradnorm: false}
 scenario: experiment_2
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}

--- a/optimisation/configs/exploitation/hpo_exploitation_mlp_nobuilding.yaml
+++ b/optimisation/configs/exploitation/hpo_exploitation_mlp_nobuilding.yaml
@@ -1,4 +1,4 @@
-hpo_settings: {data_free: true, enable_gradnorm: false, opt_epochs: 2000}
+hpo_settings: {data_free: true, enable_gradnorm: false}
 scenario: experiment_1
 domain: {lx: 1200.0, ly: 100.0, t_final: 3600.0}
 physics: {g: 9.81, inflow: null, n_manning: 0.03, u_const: 0.29}

--- a/optimisation/configs/exploration/hpo_dgm_datafree_static_building.yaml
+++ b/optimisation/configs/exploration/hpo_dgm_datafree_static_building.yaml
@@ -3,9 +3,9 @@
 hpo_settings:
   data_free: true
   enable_gradnorm: false
-  opt_epochs: 2000
 
 training:
+  epochs: 2000
   seed: 42
 
 scenario: experiment_2

--- a/optimisation/configs/exploration/hpo_dgm_datafree_static_nobuilding.yaml
+++ b/optimisation/configs/exploration/hpo_dgm_datafree_static_nobuilding.yaml
@@ -3,9 +3,9 @@
 hpo_settings:
   data_free: true
   enable_gradnorm: false
-  opt_epochs: 2000
 
 training:
+  epochs: 2000
   seed: 42
 
 model:

--- a/optimisation/configs/exploration/hpo_fourier_datafree_static_building.yaml
+++ b/optimisation/configs/exploration/hpo_fourier_datafree_static_building.yaml
@@ -5,9 +5,9 @@
 hpo_settings:
   data_free: true
   enable_gradnorm: false
-  opt_epochs: 2000
 
 training:
+  epochs: 2000
   seed: 42
 
 scenario: experiment_2
@@ -39,9 +39,6 @@ building: # Fixed geometry, Optuna suggests sampling density
   x_max: 375.0
   y_min: 25.0
   y_max: 75.0
-  nx: 20
-  ny: 20
-  nt: 20
 
 physics: # Fixed
   u_const: 0.29

--- a/optimisation/configs/exploration/hpo_fourier_datafree_static_nobuilding.yaml
+++ b/optimisation/configs/exploration/hpo_fourier_datafree_static_nobuilding.yaml
@@ -3,9 +3,9 @@
 hpo_settings:
   data_free: true
   enable_gradnorm: false
-  opt_epochs: 2000
 
 training:
+  epochs: 2000
   seed: 42
 
 model:

--- a/optimisation/configs/exploration/hpo_mlp_datafree_static_building.yaml
+++ b/optimisation/configs/exploration/hpo_mlp_datafree_static_building.yaml
@@ -3,9 +3,9 @@
 hpo_settings:
   data_free: true
   enable_gradnorm: false
-  opt_epochs: 2000
 
 training:
+  epochs: 2000
   seed: 42
 
 scenario: experiment_2

--- a/optimisation/configs/exploration/hpo_mlp_datafree_static_nobuilding.yaml
+++ b/optimisation/configs/exploration/hpo_mlp_datafree_static_nobuilding.yaml
@@ -4,9 +4,9 @@
 hpo_settings:
   data_free: true
   enable_gradnorm: false
-  opt_epochs: 2000
 
 training:
+  epochs: 2000
   seed: 42
 
 model:

--- a/optimisation/run_optimization.py
+++ b/optimisation/run_optimization.py
@@ -49,15 +49,11 @@ def main():
 
     # --- Get HPO Settings from Config ---
     hpo_settings = base_config_dict.get("hpo_settings", {})
-    opt_epochs = hpo_settings.get("opt_epochs", 5000)
+    opt_epochs = base_config_dict.get("training", {}).get("epochs", 5000)
 
     print(f"Mode: DATA-FREE (Physics Only)")
     print(f"GradNorm: Disabled")
     print(f"Optimization trials will run for {opt_epochs} epochs each.")
-
-    # --- Update base config dict with explicit opt_epochs ---
-    if "training" not in base_config_dict: base_config_dict["training"] = {}
-    base_config_dict["training"]["epochs"] = opt_epochs
 
     # --- Setup Optuna Study ---
     storage_path = setup_study_storage(args.storage, project_root)

--- a/optimisation/run_sensitivity_analysis.py
+++ b/optimisation/run_sensitivity_analysis.py
@@ -48,14 +48,11 @@ def main():
         sys.exit(1)
 
     hpo_settings = base_config_dict.get("hpo_settings", {})
-    opt_epochs = hpo_settings.get("opt_epochs", 5000)
+    opt_epochs = base_config_dict.get("training", {}).get("epochs", 5000)
 
     print(f"Mode: DATA-FREE (Physics Only)")
     print(f"GradNorm: Disabled")
     print(f"Sensitivity trials will run for {opt_epochs} epochs each.")
-
-    if "training" not in base_config_dict: base_config_dict["training"] = {}
-    base_config_dict["training"]["epochs"] = opt_epochs
 
     # --- Setup Optuna Study ---
     storage_path = setup_study_storage(args.storage, project_root)


### PR DESCRIPTION
## Summary
- Remove `opt_epochs` from `hpo_settings` in all 12 HPO configs — epochs now lives canonically in `training.epochs`
- Add missing `epochs: 2000` to `training` section in 6 exploration configs
- Remove deprecated `nx`/`ny`/`nt` from `building` section in `hpo_fourier_datafree_static_building.yaml`
- Update `run_optimization.py` and `run_sensitivity_analysis.py` to read epochs from `training.epochs` directly

## Test plan
- [x] `python -m unittest discover test` — all 83 tests pass
- [x] Verified no `opt_epochs` in active configs (`grep -r opt_epochs` only shows archive/output files)
- [x] Verified no `nx/ny/nt` in building sections

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)