### PR TITLE
Add GPU memory profiling benchmark script

### DIFF
--- a/scripts/benchmark_memory.py
+++ b/scripts/benchmark_memory.py
@@ -57,12 +57,17 @@ def _make_jac_fn(model, params):
     return jax.jit(jax.vmap(jax.jacfwd(U_fn)))
 
 
-def _make_grad_fn(model, batch):
-    """Create a JIT-compiled grad-through-Jacobian function."""
+def _make_grad_fn(model):
+    """Create a JIT-compiled grad-through-Jacobian function.
+
+    The batch is passed as an argument rather than closed over so the
+    function only needs to be compiled once per model, regardless of
+    batch size.
+    """
     return jax.jit(jax.grad(
-        lambda p: jnp.mean(jax.vmap(jax.jacfwd(
+        lambda p, b: jnp.mean(jax.vmap(jax.jacfwd(
             lambda pts: model.apply({'params': p['params']}, pts, train=False)
-        ))(batch) ** 2)
+        ))(b) ** 2)
     ))
 
 
@@ -159,11 +164,11 @@ def benchmark_scale_grid(cfg_dict, key, dtype):
                 _ = jac_fn(jnp.ones((1, 3), dtype=dtype))
                 jax.block_until_ready(_)
 
-                # Compile grad_fn once per (width, depth) config
-                max_bs = max(batch_sizes)
-                grad_batch = random.uniform(key, (max_bs, 3), dtype=dtype)
-                grad_fn = _make_grad_fn(model, grad_batch)
-                _ = grad_fn(params)
+                # Build grad_fn once per (width, depth), outside the batch_sizes
+                # loop.  The batch is passed as an argument so it can vary
+                # without recompilation.
+                grad_fn = _make_grad_fn(model)
+                _ = grad_fn(params, jnp.ones((1, 3), dtype=dtype))
                 jax.block_until_ready(_)
 
                 for bs in batch_sizes:
@@ -173,8 +178,7 @@ def benchmark_scale_grid(cfg_dict, key, dtype):
                         jax.block_until_ready(result)
 
                         # Measure grad (backward through Jacobian)
-                        grad_fn_bs = _make_grad_fn(model, batch)
-                        _ = grad_fn_bs(params)
+                        _ = grad_fn(params, batch)
                         jax.block_until_ready(_)
 
                         mem = _get_memory_bytes()


### PR DESCRIPTION
## Summary
- Adds `scripts/benchmark_memory.py` to profile GPU memory usage patterns
- Measures baseline memory after model init and optimizer creation
- Profiles peak memory during Jacobian computation at various batch sizes (256–4096)
- Runs a scale grid test: memory vs (batch_size, width, depth) to identify OOM risks
- Compares memory footprint across MLP, FourierPINN, and DGM architectures

Closes #106

## Test plan
- [x] All 83 existing tests pass
- [ ] Run `python scripts/benchmark_memory.py --config configs/experiment_1.yaml` on GPU
- [ ] Run with `--skip-grid` for quick baseline check
- [ ] Verify JSON report generation with `--output profiling/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)