### PR TITLE
Add hu/hv validation tests and data regeneration script

### DIFF
--- a/scripts/regenerate_validation_data.sh
+++ b/scripts/regenerate_validation_data.sh
@@ -14,12 +14,39 @@
 # This script is a convenience wrapper. See individual scripts for options.
 #
 # Depends on: #38 (scripts cleanup) for gauge processing pipeline.
+#
+# Usage:
+#   ./regenerate_validation_data.sh [--val-samples N] [--train-samples N]
+#                                   [--max-time T] [--seed S]
 set -euo pipefail
+
+# --- Configurable defaults (override via CLI flags) ---
+VAL_SAMPLES=65536
+TRAIN_SAMPLES=2000
+MAX_TIME=21600
+SEED=42
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --val-samples)  VAL_SAMPLES="$2"; shift 2 ;;
+        --train-samples) TRAIN_SAMPLES="$2"; shift 2 ;;
+        --max-time)     MAX_TIME="$2"; shift 2 ;;
+        --seed)         SEED="$2"; shift 2 ;;
+        -h|--help)
+            echo "Usage: $0 [--val-samples N] [--train-samples N] [--max-time T] [--seed S]"
+            echo ""
+            echo "Defaults: --val-samples $VAL_SAMPLES --train-samples $TRAIN_SAMPLES"
+            echo "          --max-time $MAX_TIME --seed $SEED"
+            exit 0 ;;
+        *) echo "Unknown option: $1"; exit 1 ;;
+    esac
+done
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
 echo "=== Regenerating validation data with hu/hv columns ==="
+echo "  val_samples=$VAL_SAMPLES  train_samples=$TRAIN_SAMPLES  max_time=$MAX_TIME  seed=$SEED"
 echo ""
 
 # --- Experiment 2: Building obstacle ---
@@ -29,12 +56,12 @@ if [ -f "$EXP2_TENSOR" ]; then
     echo "[Experiment 2] Regenerating from validation_tensor.npy..."
     python "$SCRIPT_DIR/generate_training_data.py" \
         --scenario experiment_2 \
-        --val_samples 65536 \
-        --train_samples 2000 \
-        --train_max_time 21600 \
-        --val_max_time 21600 \
-        --plot_time 21600 \
-        --seed 42
+        --val_samples "$VAL_SAMPLES" \
+        --train_samples "$TRAIN_SAMPLES" \
+        --train_max_time "$MAX_TIME" \
+        --val_max_time "$MAX_TIME" \
+        --plot_time "$MAX_TIME" \
+        --seed "$SEED"
     echo "[Experiment 2] Done."
 else
     echo "[Experiment 2] SKIP: $EXP2_TENSOR not found."
@@ -50,13 +77,18 @@ for exp_num in 3 4 5 6 7; do
     META_FILE="$EXP_DIR/gauge_metadata.csv"
 
     if [ -f "$META_FILE" ]; then
-        # Check for gauge CSV files (naming may vary)
-        DEPTH_FILE=$(find "$EXP_DIR" -name "*depth*" -name "*.csv" 2>/dev/null | head -1)
-        ANGLE_FILE=$(find "$EXP_DIR" -name "*angle*" -name "*.csv" 2>/dev/null | head -1)
-        SPEED_FILE=$(find "$EXP_DIR" -name "*speed*" -name "*.csv" 2>/dev/null | head -1)
+        # Look for gauge CSVs with specific naming patterns.
+        # Only match files directly named *_depth.csv, *_angle.csv, *_speed.csv
+        # to avoid false positives on backup or config files.
+        DEPTH_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_depth.csv" -o -name "depth_*.csv" 2>/dev/null | head -1)
+        ANGLE_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_angle.csv" -o -name "angle_*.csv" 2>/dev/null | head -1)
+        SPEED_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_speed.csv" -o -name "speed_*.csv" 2>/dev/null | head -1)
 
         if [ -n "$DEPTH_FILE" ] && [ -n "$ANGLE_FILE" ] && [ -n "$SPEED_FILE" ]; then
             echo "[Experiment $exp_num] Regenerating from gauge CSVs..."
+            echo "  depth: $(basename "$DEPTH_FILE")"
+            echo "  angle: $(basename "$ANGLE_FILE")"
+            echo "  speed: $(basename "$SPEED_FILE")"
             python "$SCRIPT_DIR/process_gauge_csvs.py" \
                 --meta "$META_FILE" \
                 --depth "$DEPTH_FILE" \
@@ -68,15 +100,15 @@ for exp_num in 3 4 5 6 7; do
             echo "[Experiment $exp_num] Done."
         else
             echo "[Experiment $exp_num] SKIP: Missing gauge CSV files in $EXP_DIR."
-            echo "  Need: depth, angle, and speed CSVs."
+            echo "  Need: *_depth.csv, *_angle.csv, and *_speed.csv."
         fi
     elif [ -f "$EXP_DIR/validation_tensor.npy" ]; then
         echo "[Experiment $exp_num] Regenerating from validation_tensor.npy..."
         python "$SCRIPT_DIR/generate_training_data.py" \
             --scenario "experiment_${exp_num}" \
-            --val_samples 65536 \
-            --train_samples 2000 \
-            --seed 42
+            --val_samples "$VAL_SAMPLES" \
+            --train_samples "$TRAIN_SAMPLES" \
+            --seed "$SEED"
         echo "[Experiment $exp_num] Done."
     else
         echo "[Experiment $exp_num] SKIP: No source data found in $EXP_DIR."

--- a/test/test_physics.py
+++ b/test/test_physics.py
@@ -148,12 +148,31 @@ class TestAnalyticalSolutions(unittest.TestCase):
         self.assertAlmostEqual(float(hu[0]), 0.0, places=10)
 
     def test_hv_exact_always_zero(self):
-        """hv = 0 everywhere (1D problem, no y-velocity)."""
+        """hv = 0 everywhere (1D problem, no y-velocity).
+
+        This is a regression guard: hv_exact returns zeros_like(x) by
+        definition for the 1D dam-break. The test ensures it isn't
+        accidentally changed to return non-zero values.
+        """
         x = jnp.array([0.0, 10.0, 100.0])
         t = jnp.array([100.0, 100.0, 100.0])
         hv = hv_exact(x, t, self.n_manning, self.u_const)
         self.assertTrue(jnp.allclose(hv, 0.0),
                         f"hv should be zero everywhere: {hv}")
+
+    def test_initial_condition_t_zero(self):
+        """At t=0, h=0 and hu=0 for all x > 0 (dry domain before dam-break)."""
+        x = jnp.array([1.0, 10.0, 100.0, 500.0])
+        t = jnp.zeros_like(x)
+        h = h_exact(x, t, self.n_manning, self.u_const)
+        hu = hu_exact(x, t, self.n_manning, self.u_const)
+        hv = hv_exact(x, t, self.n_manning, self.u_const)
+        self.assertTrue(jnp.allclose(h, 0.0, atol=1e-12),
+                        f"h should be 0 at t=0 for x>0: {h}")
+        self.assertTrue(jnp.allclose(hu, 0.0, atol=1e-12),
+                        f"hu should be 0 at t=0 for x>0: {hu}")
+        self.assertTrue(jnp.allclose(hv, 0.0, atol=1e-12),
+                        f"hv should be 0 at t=0: {hv}")
 
     def test_h_exact_at_origin(self):
         """h at x=0 grows with time (dam-break spreading)."""


### PR DESCRIPTION
## Summary
- Add 6 unit tests for `hu_exact()` and `hv_exact()` analytical solutions in `test_physics.py`, verifying correctness of the dam-break hu/hv formulas
- Add `scripts/regenerate_validation_data.sh` convenience script to regenerate validation `.npy` files with 6 columns `[t,x,y,h,u,v]` for experiments 2-7

**Note:** The code infrastructure for hu/hv metrics already exists on `claude-cleanup`:
- `src/physics/analytical.py` has `hu_exact()` and `hv_exact()`
- Experiment 1 already computes `nse_hu`, `rmse_hu`, `nse_hv`, `rmse_hv`
- The training loop computes hu/hv metrics when `val_targets` has 3+ columns
- `load_validation_data` handles both 4-column and 6-column formats

The remaining work (regenerating actual validation data files for experiments 2-7) requires ICM simulation data and depends on #38.

## Test plan
- [x] All 12 physics tests pass (`python -m pytest test/test_physics.py -v`)
- [ ] Verify regeneration script runs when source data is available
- [ ] Verify experiments show hu/hv metrics in Aim when trained with 6-column validation data

Partially addresses #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)