### PR TITLE
fix: W&B image logging to Media/Images panel

### DIFF
--- a/src/monitoring/wandb_tracker.py
+++ b/src/monitoring/wandb_tracker.py
@@ -370,12 +370,12 @@ class WandbTracker:
             self._run_files_artifact = None
 
     def log_image(self, path: str, name: str):
-        """Log an image to the run summary (no extra history step)."""
+        """Log an image so it appears in the W&B Media/Images panel."""
         if not self.enabled:
             return
         try:
             import wandb
-            self.run.summary[f"images/{name}"] = wandb.Image(path)
+            self.run.log({f"images/{name}": wandb.Image(path)}, commit=False)
         except Exception as e:
             print(f"Warning: Failed to log image '{name}': {e}")
 


### PR DESCRIPTION
## Summary
- Change `log_image()` from `run.summary[...] = wandb.Image()` to `run.log({...}, commit=False)`
- Images now appear in the browsable Media/Images panel in W&B UI
- `commit=False` prevents incrementing the global step counter

Closes #148

## Test plan
- [x] All callers verified — post-training result plots only, no step dependency
- [x] `commit=False` images flushed by `run.finish()`
- [ ] Verify images appear in W&B Media/Images tab after a training run

🤖 Generated with [Claude Code](https://claude.com/claude-code)