### PR TITLE
fix: model logging with run.log_model(), remove source script artifacts

### DIFF
--- a/experiments/experiment_1/train.py
+++ b/experiments/experiment_1/train.py
@@ -395,7 +395,6 @@ def main(config_path: str):
         model_dir=model_dir,
         config_path=config_path,
         validation_fn=ctx["validation_fn"],
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_1/train_relobralo.py
+++ b/experiments/experiment_1/train_relobralo.py
@@ -114,7 +114,6 @@ def _run_relobralo_loop(
     trial_name, results_dir, model_dir,
     config_path,
     validation_fn=None,
-    source_script_path=None,
     compute_all_losses_fn=None,
 ):
     """Epoch loop with per-epoch ReLoBRaLo weight updates.
@@ -129,8 +128,6 @@ def _run_relobralo_loop(
     if wandb_enabled:
         try:
             tracker.log_artifact(config_path, 'run_config.yaml')
-            if source_script_path is not None:
-                tracker.log_artifact(os.path.abspath(source_script_path), 'source_script.py')
         except Exception:
             pass
 
@@ -620,7 +617,6 @@ def main(config_path: str):
         model_dir=model_dir,
         config_path=config_path,
         validation_fn=ctx["validation_fn"],
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_2/train.py
+++ b/experiments/experiment_2/train.py
@@ -400,7 +400,6 @@ def main(config_path: str):
         model_dir=model_dir,
         config_path=config_path,
         validation_fn=ctx["validation_fn"],
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_3/train.py
+++ b/experiments/experiment_3/train.py
@@ -317,7 +317,6 @@ def main(config_path: str):
         val_points_all=ctx.get("val_points_all"),
         h_true_val_all=ctx.get("h_true_val_all"),
         val_targets_all=ctx.get("val_targets_all"),
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_4/train.py
+++ b/experiments/experiment_4/train.py
@@ -322,7 +322,6 @@ def main(config_path: str):
         val_points_all=ctx.get("val_points_all"),
         h_true_val_all=ctx.get("h_true_val_all"),
         val_targets_all=ctx.get("val_targets_all"),
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_5/train.py
+++ b/experiments/experiment_5/train.py
@@ -305,7 +305,6 @@ def main(config_path: str):
         val_points_all=ctx.get("val_points_all"),
         h_true_val_all=ctx.get("h_true_val_all"),
         val_targets_all=ctx.get("val_targets_all"),
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_6/train.py
+++ b/experiments/experiment_6/train.py
@@ -324,7 +324,6 @@ def main(config_path: str):
         val_points_all=ctx.get("val_points_all"),
         h_true_val_all=ctx.get("h_true_val_all"),
         val_targets_all=ctx.get("val_targets_all"),
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_7/train.py
+++ b/experiments/experiment_7/train.py
@@ -333,7 +333,6 @@ def main(config_path: str):
         val_points_all=ctx.get("val_points_all"),
         h_true_val_all=ctx.get("h_true_val_all"),
         val_targets_all=ctx.get("val_targets_all"),
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/experiments/experiment_8/train.py
+++ b/experiments/experiment_8/train.py
@@ -383,7 +383,6 @@ def main(config_path: str):
         pde_key_for_diag="pde",
         validation_fn=ctx["validation_fn"],
         selection_metric_key="selection_metric",
-        source_script_path=__file__,
         compute_all_losses_fn=ctx["compute_all_losses_fn"],
     )
 

--- a/scripts/cleanup_wandb_artifacts.py
+++ b/scripts/cleanup_wandb_artifacts.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""One-time cleanup: delete empty W&B artifact collections.
+
+Usage:
+    python scripts/cleanup_wandb_artifacts.py [--dry-run]
+"""
+import argparse
+
+import wandb
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Delete empty W&B artifact collections")
+    parser.add_argument("--dry-run", action="store_true", help="List but don't delete")
+    parser.add_argument("--entity", default="zeinali72-exeter")
+    parser.add_argument("--project", default="swe-pinn")
+    args = parser.parse_args()
+
+    api = wandb.Api()
+    collections = api.artifact_type_collections(args.project, args.entity)
+
+    deleted = 0
+    for col in collections:
+        versions = list(col.versions())
+        if len(versions) == 0:
+            if args.dry_run:
+                print(f"[dry-run] Would delete: {col.name} (type={col.type})")
+            else:
+                try:
+                    col.delete()
+                    print(f"Deleted: {col.name} (type={col.type})")
+                    deleted += 1
+                except Exception as e:
+                    print(f"Failed to delete {col.name}: {e}")
+
+    print(f"\n{'Would delete' if args.dry_run else 'Deleted'} {deleted} empty collections.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cleanup_wandb_artifacts.py
+++ b/scripts/cleanup_wandb_artifacts.py
@@ -23,13 +23,13 @@ def main():
     for col in collections:
         versions = list(col.versions())
         if len(versions) == 0:
+            deleted += 1
             if args.dry_run:
                 print(f"[dry-run] Would delete: {col.name} (type={col.type})")
             else:
                 try:
                     col.delete()
                     print(f"Deleted: {col.name} (type={col.type})")
-                    deleted += 1
                 except Exception as e:
                     print(f"Failed to delete {col.name}: {e}")
 

--- a/src/monitoring/wandb_tracker.py
+++ b/src/monitoring/wandb_tracker.py
@@ -418,32 +418,28 @@ class WandbTracker:
     # ------------------------------------------------------------------
     # Model registry (W&B Artifacts with type="model")
     # ------------------------------------------------------------------
-    def register_best_model(self, model_path: str) -> Optional[str]:
-        """Log the best checkpoint as a model artifact.
-
-        The artifact is named ``model_{trial_name}`` where trial_name
-        already contains timestamp + scenario + arch (e.g.
-        ``model_2025-03-19_14-32_experiment_1_fourierpinn``).
-        Each run produces a uniquely named artifact.
+    def register_best_model(self, model_path: str, metadata: dict = None) -> None:
+        """Log the best checkpoint via ``run.log_model()``.
 
         Parameters
         ----------
         model_path : str
             Local path to the model weights file.
+        metadata : dict, optional
+            Extra metadata (NSE, RMSE, epoch, architecture, training time).
         """
         if not self.enabled:
-            return None
+            return
         try:
-            import wandb
-            name = f"model_{self._trial_name}"
-            artifact = wandb.Artifact(name=name, type="model")
-            artifact.add_file(model_path, name=os.path.basename(model_path))
-            self.run.log_artifact(artifact)
-            print(f"Model artifact registered: {name}")
-            return self.run.id
+            self.run.log_model(
+                path=model_path,
+                name=f"model_{self._trial_name}",
+                aliases=["best"],
+                metadata=metadata,
+            )
+            print(f"Model logged: model_{self._trial_name}")
         except Exception as e:
             print(f"Warning: Failed to register model in W&B: {e}")
-            return None
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/src/monitoring/wandb_tracker.py
+++ b/src/monitoring/wandb_tracker.py
@@ -418,15 +418,13 @@ class WandbTracker:
     # ------------------------------------------------------------------
     # Model registry (W&B Artifacts with type="model")
     # ------------------------------------------------------------------
-    def register_best_model(self, model_path: str, metadata: dict = None) -> None:
+    def register_best_model(self, model_path: str) -> None:
         """Log the best checkpoint via ``run.log_model()``.
 
         Parameters
         ----------
         model_path : str
             Local path to the model weights file.
-        metadata : dict, optional
-            Extra metadata (NSE, RMSE, epoch, architecture, training time).
         """
         if not self.enabled:
             return
@@ -435,7 +433,6 @@ class WandbTracker:
                 path=model_path,
                 name=f"model_{self._trial_name}",
                 aliases=["best"],
-                metadata=metadata,
             )
             print(f"Model logged: model_{self._trial_name}")
         except Exception as e:

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -44,7 +44,6 @@ def run_training_loop(
     pde_key_for_diag="pde",
     validation_fn=None,
     selection_metric_key="nse_h",
-    source_script_path=None,
     compute_all_losses_fn=None,
 ):
     """Execute the full epoch loop with logging, checkpointing, and early stopping.
@@ -81,8 +80,6 @@ def run_training_loop(
     if wandb_enabled:
         try:
             tracker.log_artifact(config_path, 'run_config.yaml')
-            if source_script_path is not None:
-                tracker.log_artifact(os.path.abspath(source_script_path), 'source_script.py')
         except Exception:
             pass
     console = ConsoleLogger(cfg_dict)


### PR DESCRIPTION
## Summary
- Replace manual `wandb.Artifact` model registration with `run.log_model()` (aliases=["best"])
- Remove `source_script_path` parameter from `run_training_loop()` and all 9 experiment callers
- Remove source script artifact upload from `loop.py` and `train_relobralo.py`
- Add `scripts/cleanup_wandb_artifacts.py` for one-time empty artifact collection cleanup

Closes #149

## Test plan
- [x] `test_train` passes
- [x] No dangling `source_script_path` references (grep verified)
- [x] `run.log_model()` signature verified against installed wandb SDK
- [ ] Run cleanup script with `--dry-run` to verify empty collections detected
- [ ] Verify model artifact appears correctly in W&B after training

🤖 Generated with [Claude Code](https://claude.com/claude-code)