### PR TITLE
feat: enable W&B git commit tracking and Code Comparer

### DIFF
--- a/src/monitoring/wandb_tracker.py
+++ b/src/monitoring/wandb_tracker.py
@@ -157,8 +157,12 @@ class WandbTracker:
                 group=group,
                 tags=tags,
                 config=flat_config,
+                save_code=True,
                 reinit=True,
             )
+
+            # Snapshot all Python source for the Code Comparer panel
+            self.run.log_code(".", include_fn=lambda path: path.endswith(".py"))
 
             # Log additional metadata
             self.run.config.update({


### PR DESCRIPTION
## Summary
- Add `save_code=True` to `wandb.init()` — captures git commit SHA and `diff.patch` in run Overview
- Add `run.log_code(".")` with `.py` filter — enables Code Comparer panel between runs
- `source_script_path` removal was already completed in PR #154

Closes #150

## Test plan
- [x] Code review: no sensitive files leaked (`.py` filter only)
- [x] `save_code` is read-only on git (never commits/pushes)
- [ ] Verify git SHA appears in W&B run Overview tab after training
- [ ] Verify Code Comparer panel works between two runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)