### PR TITLE
chore: remove stale keys from experiment config YAML files

### DIFF
--- a/configs/experiment_1_dgm_static.yaml
+++ b/configs/experiment_1_dgm_static.yaml
@@ -2,7 +2,6 @@ experiment:
   name: experiment_2
 
 data_free: true
-opt_epochs: 20000
 data:
   root_dir: data
   training_file: training_dataset_sample.npy

--- a/configs/experiment_1_fourier.yaml
+++ b/configs/experiment_1_fourier.yaml
@@ -30,22 +30,6 @@ domain:
   ly: 100.0                      # Length of the domain in y-direction (m)
   t_final: 3600.0                # Final time of simulation (s)
 
-grid:
-  nx: 48                         # Number of grid points in x-direction for PDE
-  ny: 23                         # Number of grid points in y-direction for PDE
-  nt: 21                         # Number of grid points in time for PDE
-
-ic_bc_grid:
-  nx_ic: 39                      # Number of grid points in x for initial condition
-  ny_ic: 33                      # Number of grid points in y for initial condition
-  ny_bc_left: 24                 # Number of grid points in y for left boundary
-  nt_bc_left: 18                 # Number of grid points in time for left boundary
-  ny_bc_right: 33                # Number of grid points in y for right boundary
-  nt_bc_right: 11                # Number of grid points in time for right boundary
-  nx_bc_bottom: 70               # Number of grid points in x for bottom boundary
-  nt_bc_other: 15                # Number of grid points in time for other boundaries
-  nx_bc_top: 69                  # Number of grid points in x for top boundary
-
 physics:
   u_const: 0.29                  # Constant velocity (m/s)
   n_manning: 0.03                # Manning's roughness coefficient

--- a/configs/experiment_3.yaml
+++ b/configs/experiment_3.yaml
@@ -69,8 +69,3 @@ reporting:
   epoch_freq: 100
 # --- REQUIRED: Needed for folder naming ---
 CONFIG_PATH: configs/train/test1_fourier_final.yaml
-
-
-softadapt:
-  enable: true
-  warmup_epochs: 100


### PR DESCRIPTION
## Summary
- `configs/experiment_3.yaml` — remove unused `softadapt` block (no Python code reads it)
- `configs/experiment_1_dgm_static.yaml` — remove unused `opt_epochs` key (no Python code reads it)
- `configs/experiment_1_fourier.yaml` — remove redundant `grid` and `ic_bc_grid` blocks

Closes #151

## Test plan
- [x] `test_train` passes
- [x] Verified via grep: `softadapt` and `opt_epochs` have zero Python consumers
- [x] Config-only change — no code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)