### PR TITLE
Rename data files to descriptive naming registry

### DIFF
--- a/configs/experiment_1_dgm_static.yaml
+++ b/configs/experiment_1_dgm_static.yaml
@@ -4,8 +4,8 @@ experiment:
 data_free: true
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_sample.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_lhs_points.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_3.yaml
+++ b/configs/experiment_3.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_3
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_4.yaml
+++ b/configs/experiment_4.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_4
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_5.yaml
+++ b/configs/experiment_5.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_5
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_6.yaml
+++ b/configs/experiment_6.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_6
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_7.yaml
+++ b/configs/experiment_7.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_7
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_8.yaml
+++ b/configs/experiment_8.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_8
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/experiments/experiment_2/train.py
+++ b/experiments/experiment_2/train.py
@@ -155,12 +155,12 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     validation_data_file = os.path.join(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_sample.npy"),
+        get_data_filename(cfg, "validation_file", "val_lhs_points.npy"),
     )
     validation_data_loaded = False
     val_hu_true = None

--- a/experiments/experiment_3/train.py
+++ b/experiments/experiment_3/train.py
@@ -149,14 +149,14 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
         verbose=not hpo_mode,
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
         verbose=not hpo_mode,
     )
     validation_data_loaded = validation["loaded"]

--- a/experiments/experiment_4/train.py
+++ b/experiments/experiment_4/train.py
@@ -146,13 +146,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_5/train.py
+++ b/experiments/experiment_5/train.py
@@ -140,13 +140,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_6/train.py
+++ b/experiments/experiment_6/train.py
@@ -137,13 +137,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_7/train.py
+++ b/experiments/experiment_7/train.py
@@ -174,13 +174,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # E. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_8/train.py
+++ b/experiments/experiment_8/train.py
@@ -180,13 +180,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # E. Load Validation Data (Ground Truth)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_8/train_imp_samp.py
+++ b/experiments/experiment_8/train_imp_samp.py
@@ -286,7 +286,7 @@ def main(config_path: str):
     data_free_flag = cfg.get("data_free")
     has_data_loss = not data_free_flag
     
-    training_data_file = os.path.join(base_data_path, "training_dataset_sample.npy")
+    training_data_file = os.path.join(base_data_path, "train_lhs_points.npy")
     if has_data_loss: 
         if os.path.exists(training_data_file):
             try:
@@ -301,7 +301,7 @@ def main(config_path: str):
             has_data_loss = False
     data_free = not has_data_loss 
 
-    validation_data_file = os.path.join(base_data_path, "validation_gauges_ground_truth.npy")
+    validation_data_file = os.path.join(base_data_path, "val_gauges_gt.npy")
     validation_data_loaded = False
     val_pts_batch = None
     val_h_true = None

--- a/optimisation/configs/exploration/hpo_dgm_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_dgm_experiment_3.yaml
@@ -14,8 +14,8 @@ experiment:
 
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 training:
   epochs: 500

--- a/optimisation/configs/exploration/hpo_fourier_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_fourier_experiment_3.yaml
@@ -14,8 +14,8 @@ experiment:
 
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 training:
   epochs: 500

--- a/optimisation/configs/exploration/hpo_mlp_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_mlp_experiment_3.yaml
@@ -14,8 +14,8 @@ experiment:
 
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 training:
   epochs: 500

--- a/scripts/binary_to_numpy.py
+++ b/scripts/binary_to_numpy.py
@@ -2,14 +2,14 @@
 
 This is stage 2 of the preprocessing pipeline:
   1. InfoWorks ICM CSV -> binary (cpp/preprocess.cpp via run_preprocess.sh)
-  2. Binary -> .npy (this script)
-  3. .npy tensor -> training/validation/plotting datasets (generate_training_data.py)
+  2. Binary -> .npy (this script): val_full_domain.bin -> val_full_domain.npy
+  3. .npy -> training/validation datasets (generate_training_data.py or src/data/loader.py)
 
 The binary file contains rows of 6 float64 values: [t, x, y, h, u, v].
 Output is saved as float32 to reduce file size.
 
 Usage:
-    python binary_to_numpy.py input.bin output.npy
+    python binary_to_numpy.py val_full_domain.bin val_full_domain.npy
 """
 import numpy as np
 import argparse

--- a/scripts/filter_by_time.py
+++ b/scripts/filter_by_time.py
@@ -4,7 +4,7 @@ Reads a .npy file where the first column is time (t), keeps only rows where
 t <= max_time, and saves the filtered result to a new file.
 
 Usage:
-    python filter_by_time.py validation_sample.npy --max_time 3600
+    python filter_by_time.py val_lhs_points.npy --max_time 3600
 """
 import numpy as np
 import os
@@ -13,12 +13,12 @@ from pathlib import Path
 
 def filter_validation_sample_by_time(input_npy_path: str, max_time: float = 3600.0) -> None:
     """
-    Loads a validation_sample.npy file, filters it to keep rows where
+    Loads a val_lhs_points.npy file, filters it to keep rows where
     time (first column) is less than or equal to max_time, and saves
     the filtered data to a new file in the same directory.
 
     Args:
-        input_npy_path (str): Path to the input validation_sample.npy file.
+        input_npy_path (str): Path to the input val_lhs_points.npy file.
         max_time (float): The maximum time value (inclusive) to keep.
                           Defaults to 3600.0.
     """
@@ -62,12 +62,12 @@ def filter_validation_sample_by_time(input_npy_path: str, max_time: float = 3600
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description=f"Filter a validation_sample.npy file based on a maximum time value."
+        description=f"Filter a val_lhs_points.npy file based on a maximum time value."
     )
     parser.add_argument(
         "input_file",
         type=str,
-        help="Path to the input validation_sample.npy file."
+        help="Path to the input val_lhs_points.npy file."
     )
     parser.add_argument(
         "--max_time",
@@ -79,11 +79,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # --- Example Usage ---
-    # Assuming your file is in 'data/one_building_DEM_zero/validation_sample.npy'
+    # Assuming your file is in 'data/one_building_DEM_zero/val_lhs_points.npy'
     # You would run this script like:
-    # python <script_name>.py data/one_building_DEM_zero/validation_sample.npy --max_time 3600.0
+    # python <script_name>.py data/one_building_DEM_zero/val_lhs_points.npy --max_time 3600.0
     # Or simply:
-    # python <script_name>.py data/one_building_DEM_zero/validation_sample.npy
+    # python <script_name>.py data/one_building_DEM_zero/val_lhs_points.npy
     # (since 3600.0 is the default max_time)
 
     filter_validation_sample_by_time(args.input_file, args.max_time)

--- a/scripts/generate_training_data.py
+++ b/scripts/generate_training_data.py
@@ -61,16 +61,16 @@ def create_datasets(
 
     # --- 1. Define File Paths ---
     base_path = Path('data') / scenario_name
-    input_file = base_path / 'validation_tensor.npy'
-    val_sample_file = base_path / 'validation_sample.npy'
-    train_sample_file = base_path / 'training_dataset_sample.npy'
+    input_file = base_path / 'val_full_domain.npy'
+    val_sample_file = base_path / 'val_lhs_points.npy'
+    train_sample_file = base_path / 'train_lhs_points.npy'
     plot_file = base_path / f'validation_plotting_t_{int(plotting_time)}s.npy'
 
     if not base_path.exists():
         print(f"Error: Scenario directory not found at {base_path}")
         return
     if not input_file.exists():
-        print(f"Error: Input file validation_tensor.npy not found at {input_file}")
+        print(f"Error: Input file val_full_domain.npy not found at {input_file}")
         return
 
     print(f"Input tensor: {input_file}")

--- a/scripts/process_gauge_csvs.py
+++ b/scripts/process_gauge_csvs.py
@@ -21,13 +21,13 @@ Column conventions:
 
 Usage:
     # Merged mode (single output)
-    python process_gauge_csvs.py --meta meta.csv --depth depth.csv \\
-        --angle angle.csv --speed speed.csv --output gauges.npy
+    python process_gauge_csvs.py --meta gauge_metadata.csv --depth gauge_depth.csv \\
+        --angle gauge_angle.csv --speed gauge_speed.csv --output gauge_data.npy
 
     # Split mode (train/val outputs)
-    python process_gauge_csvs.py --meta meta.csv --depth depth.csv \\
-        --angle angle.csv --speed speed.csv --split \\
-        --output_train train.npy --output_val val.npy
+    python process_gauge_csvs.py --meta gauge_metadata.csv --depth gauge_depth.csv \\
+        --angle gauge_angle.csv --speed gauge_speed.csv --split \\
+        --output_train train_gauges.npy --output_val val_gauges_gt.npy
 """
 
 import pandas as pd

--- a/scripts/regenerate_validation_data.sh
+++ b/scripts/regenerate_validation_data.sh
@@ -5,7 +5,7 @@
 # the training loop can compute NSE/RMSE for hu and hv in addition to h.
 #
 # Prerequisites:
-#   - Raw ICM simulation data must exist as validation_tensor.npy (6 columns)
+#   - Raw ICM simulation data must exist as val_full_domain.npy (6 columns)
 #     under data/experiment_N/. If only 4-column tensors exist, re-run the
 #     full pipeline from ICM CSV -> binary -> .npy first.
 #   - For gauge-based experiments (3-7), the gauge CSVs (depth, angle, speed)
@@ -50,10 +50,10 @@ echo "  val_samples=$VAL_SAMPLES  train_samples=$TRAIN_SAMPLES  max_time=$MAX_TI
 echo ""
 
 # --- Experiment 2: Building obstacle ---
-# Uses generate_training_data.py which samples from validation_tensor.npy
-EXP2_TENSOR="$PROJECT_ROOT/data/experiment_2/validation_tensor.npy"
+# Uses generate_training_data.py which samples from val_full_domain.npy
+EXP2_TENSOR="$PROJECT_ROOT/data/experiment_2/val_full_domain.npy"
 if [ -f "$EXP2_TENSOR" ]; then
-    echo "[Experiment 2] Regenerating from validation_tensor.npy..."
+    echo "[Experiment 2] Regenerating from val_full_domain.npy..."
     python "$SCRIPT_DIR/generate_training_data.py" \
         --scenario experiment_2 \
         --val_samples "$VAL_SAMPLES" \
@@ -96,14 +96,14 @@ for exp_num in 3 4 5 6 7; do
                 --speed "$SPEED_FILE" \
                 --split \
                 --output_train "$EXP_DIR/training_gauges.npy" \
-                --output_val "$EXP_DIR/validation_gauges.npy"
+                --output_val "$EXP_DIR/val_gauges_gt.npy"
             echo "[Experiment $exp_num] Done."
         else
             echo "[Experiment $exp_num] SKIP: Missing gauge CSV files in $EXP_DIR."
             echo "  Need: *_depth.csv, *_angle.csv, and *_speed.csv."
         fi
-    elif [ -f "$EXP_DIR/validation_tensor.npy" ]; then
-        echo "[Experiment $exp_num] Regenerating from validation_tensor.npy..."
+    elif [ -f "$EXP_DIR/val_full_domain.npy" ]; then
+        echo "[Experiment $exp_num] Regenerating from val_full_domain.npy..."
         python "$SCRIPT_DIR/generate_training_data.py" \
             --scenario "experiment_${exp_num}" \
             --val_samples "$VAL_SAMPLES" \
@@ -119,6 +119,6 @@ done
 echo "=== Validation data regeneration complete ==="
 echo ""
 echo "Verify column counts with:"
-echo "  python -c \"import numpy as np; d=np.load('data/experiment_N/validation_sample.npy'); print(d.shape)\""
+echo "  python -c \"import numpy as np; d=np.load('data/experiment_N/val_lhs_points.npy'); print(d.shape)\""
 echo ""
 echo "Expected: (N, 6) with columns [t, x, y, h, u, v]"

--- a/scripts/regenerate_validation_data.sh
+++ b/scripts/regenerate_validation_data.sh
@@ -96,7 +96,7 @@ for exp_num in 3 4 5 6 7; do
                 --angle "$ANGLE_FILE" \
                 --speed "$SPEED_FILE" \
                 --split \
-                --output_train "$EXP_DIR/training_gauges.npy" \
+                --output_train "$EXP_DIR/train_gauges.npy" \
                 --output_val "$EXP_DIR/val_gauges_gt.npy"
             echo "[Experiment $exp_num] Done."
         else

--- a/scripts/regenerate_validation_data.sh
+++ b/scripts/regenerate_validation_data.sh
@@ -8,8 +8,8 @@
 #   - Raw ICM simulation data must exist as val_full_domain.npy (6 columns)
 #     under data/experiment_N/. If only 4-column tensors exist, re-run the
 #     full pipeline from ICM CSV -> binary -> .npy first.
-#   - For gauge-based experiments (3-7), the gauge CSVs (depth, angle, speed)
-#     and metadata CSV must be available.
+#   - For gauge-based experiments (3-7), gauge CSVs (gauge_depth.csv,
+#     gauge_angle.csv, gauge_speed.csv) and gauge_metadata.csv must exist.
 #
 # This script is a convenience wrapper. See individual scripts for options.
 #
@@ -77,12 +77,13 @@ for exp_num in 3 4 5 6 7; do
     META_FILE="$EXP_DIR/gauge_metadata.csv"
 
     if [ -f "$META_FILE" ]; then
-        # Look for gauge CSVs with specific naming patterns.
-        # Only match files directly named *_depth.csv, *_angle.csv, *_speed.csv
-        # to avoid false positives on backup or config files.
-        DEPTH_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_depth.csv" -o -name "depth_*.csv" 2>/dev/null | head -1)
-        ANGLE_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_angle.csv" -o -name "angle_*.csv" 2>/dev/null | head -1)
-        SPEED_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_speed.csv" -o -name "speed_*.csv" 2>/dev/null | head -1)
+        # Look for gauge CSVs: prefer canonical names, fall back to glob.
+        DEPTH_FILE="$EXP_DIR/gauge_depth.csv"
+        ANGLE_FILE="$EXP_DIR/gauge_angle.csv"
+        SPEED_FILE="$EXP_DIR/gauge_speed.csv"
+        [ -f "$DEPTH_FILE" ] || DEPTH_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_depth.csv" -o -name "depth_*.csv" 2>/dev/null | head -1)
+        [ -f "$ANGLE_FILE" ] || ANGLE_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_angle.csv" -o -name "angle_*.csv" 2>/dev/null | head -1)
+        [ -f "$SPEED_FILE" ] || SPEED_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_speed.csv" -o -name "speed_*.csv" 2>/dev/null | head -1)
 
         if [ -n "$DEPTH_FILE" ] && [ -n "$ANGLE_FILE" ] && [ -n "$SPEED_FILE" ]; then
             echo "[Experiment $exp_num] Regenerating from gauge CSVs..."

--- a/scripts/run_preprocess.sh
+++ b/scripts/run_preprocess.sh
@@ -20,6 +20,10 @@ set -e  # Exit immediately if a command exits with a non-zero status
 #
 # Usage:
 #   ./run_preprocess.sh <angle_csv> <depth_csv> <speed_csv> <output_bin>
+#
+# CSV naming convention:
+#   Full domain exports:  full_domain_angle.csv, full_domain_depth.csv, full_domain_speed.csv
+#   Gauge sensor exports: gauge_angle.csv, gauge_depth.csv, gauge_speed.csv
 # =============================================================================
 
 # 1. Define where the C++ source code now lives

--- a/src/inference/experiment_registry.py
+++ b/src/inference/experiment_registry.py
@@ -39,7 +39,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_5": {
         "domain_type": "rectangular",
@@ -48,7 +48,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": ["overtopping"],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_6": {
         "domain_type": "rectangular",
@@ -57,7 +57,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_7": {
         "domain_type": "irregular",
@@ -66,7 +66,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_8": {
         "domain_type": "irregular",
@@ -75,7 +75,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": ["per_building_slip", "street_corridor"],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
 }
 
@@ -89,5 +89,5 @@ def get_experiment_meta(experiment_name: str) -> dict:
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     })

--- a/src/inference/experiment_registry.py
+++ b/src/inference/experiment_registry.py
@@ -21,7 +21,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": ["building_split"],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_3": {
         "domain_type": "rectangular",
@@ -30,7 +30,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_gauges.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_4": {
         "domain_type": "rectangular",
@@ -39,7 +39,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_5": {
         "domain_type": "rectangular",
@@ -48,7 +48,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": ["overtopping"],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_6": {
         "domain_type": "rectangular",
@@ -57,7 +57,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_7": {
         "domain_type": "irregular",
@@ -66,7 +66,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_8": {
         "domain_type": "irregular",
@@ -75,7 +75,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": ["per_building_slip", "street_corridor"],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
 }
 
@@ -89,5 +89,5 @@ def get_experiment_meta(experiment_name: str) -> dict:
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     })

--- a/src/inference/runner.py
+++ b/src/inference/runner.py
@@ -57,7 +57,7 @@ def _load_validation(cfg_dict, paths_info, meta, experiment_name):
         return _generate_analytical_validation(cfg_dict)
 
     val_file = get_data_filename(cfg_dict, "validation_file",
-                                 meta.get("default_val_file", "validation_sample.npy"))
+                                 meta.get("default_val_file", "val_lhs_points.npy"))
     val_path = os.path.join(paths_info["base_data_path"], val_file)
 
     if not os.path.exists(val_path):

--- a/src/training/data_loading.py
+++ b/src/training/data_loading.py
@@ -34,7 +34,7 @@ def resolve_data_mode(cfg, verbose=True):
 
 
 def load_training_data(base_data_path, has_data_loss, static_weights_dict,
-                       filename="training_dataset_sample.npy", verbose=True):
+                       filename="train_lhs_points.npy", verbose=True):
     """Load the training data .npy file if data-driven mode is active.
 
     Returns
@@ -79,7 +79,7 @@ def load_training_data(base_data_path, has_data_loss, static_weights_dict,
     return data_points_full, has_data_loss, data_free
 
 
-def load_validation_from_file(base_data_path, filename="validation_gauges.npy", verbose=True):
+def load_validation_from_file(base_data_path, filename="val_gauges_gt.npy", verbose=True):
     """Load validation gauge data if it exists.
 
     Returns


### PR DESCRIPTION
## Summary
- Renamed all data file references to follow a consistent descriptive convention:
  - `training_dataset_sample.npy` → `train_lhs_points.npy`
  - `validation_tensor.npy/.bin` → `val_full_domain.npy/.bin`
  - `validation_gauges_ground_truth.npy` → `val_gauges_gt.npy`
  - `validation_sample.npy` → `val_lhs_points.npy`
  - `validation_gauges.npy` → `val_gauges_gt.npy`
- Updated 24 tracked files: scripts, experiment train.py, configs, inference registry
- Renamed 30 data files on disk (gitignored)

## Test plan
- [ ] `grep -rn "training_dataset_sample\|validation_tensor\.\|validation_gauges_ground_truth\|validation_sample\." --include="*.py" --include="*.yaml" src/ experiments/ configs/ scripts/` returns zero matches
- [ ] `python -m unittest discover test` passes
- [ ] Training scripts find renamed data files

Closes #160