### PR TITLE
Implement config-driven LHS data loader

### DIFF
--- a/configs/experiment_1_dgm_static.yaml
+++ b/configs/experiment_1_dgm_static.yaml
@@ -4,8 +4,8 @@ experiment:
 data_free: true
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_sample.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_lhs_points.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_1_dgm_static.yaml
+++ b/configs/experiment_1_dgm_static.yaml
@@ -4,6 +4,8 @@ experiment:
 data_free: true
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_lhs_points.npy
 

--- a/configs/experiment_3.yaml
+++ b/configs/experiment_3.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_3
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_3.yaml
+++ b/configs/experiment_3.yaml
@@ -4,6 +4,8 @@ experiment:
 scenario: experiment_3
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/configs/experiment_4.yaml
+++ b/configs/experiment_4.yaml
@@ -4,6 +4,8 @@ experiment:
 scenario: experiment_4
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/configs/experiment_4.yaml
+++ b/configs/experiment_4.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_4
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_5.yaml
+++ b/configs/experiment_5.yaml
@@ -4,6 +4,8 @@ experiment:
 scenario: experiment_5
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/configs/experiment_5.yaml
+++ b/configs/experiment_5.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_5
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_6.yaml
+++ b/configs/experiment_6.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_6
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_6.yaml
+++ b/configs/experiment_6.yaml
@@ -4,6 +4,8 @@ experiment:
 scenario: experiment_6
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/configs/experiment_7.yaml
+++ b/configs/experiment_7.yaml
@@ -4,6 +4,8 @@ experiment:
 scenario: experiment_7
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/configs/experiment_7.yaml
+++ b/configs/experiment_7.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_7
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/configs/experiment_8.yaml
+++ b/configs/experiment_8.yaml
@@ -4,6 +4,8 @@ experiment:
 scenario: experiment_8
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/configs/experiment_8.yaml
+++ b/configs/experiment_8.yaml
@@ -4,8 +4,8 @@ experiment:
 scenario: experiment_8
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges_ground_truth.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 sampling_defaults:
   n_points_pde: 1000

--- a/experiments/experiment_2/train.py
+++ b/experiments/experiment_2/train.py
@@ -49,7 +49,7 @@ from src.training import (
     get_experiment_name,
     get_sampling_count_from_config,
     init_model_from_config,
-    load_training_data,
+    resolve_training_data,
     train_step_jitted,
     make_scan_body,
     sample_and_batch,
@@ -151,11 +151,11 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
     has_building = "building" in cfg
 
     data_free, has_data_loss = resolve_data_mode(cfg)
-    data_points_full, has_data_loss, data_free = load_training_data(
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     validation_data_file = os.path.join(

--- a/experiments/experiment_2/train.py
+++ b/experiments/experiment_2/train.py
@@ -155,12 +155,12 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     validation_data_file = os.path.join(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_sample.npy"),
+        get_data_filename(cfg, "validation_file", "val_lhs_points.npy"),
     )
     validation_data_loaded = False
     val_hu_true = None

--- a/experiments/experiment_3/train.py
+++ b/experiments/experiment_3/train.py
@@ -42,7 +42,7 @@ from src.training import (
     get_sampling_count_from_config,
     get_boundary_segment_count,
     init_model_from_config,
-    load_training_data,
+    resolve_training_data,
     load_validation_from_file,
     train_step_jitted,
     make_scan_body,
@@ -145,11 +145,11 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
     # --- Load Validation and Training Data ---
     data_points_full = None
     data_free, has_data_loss = resolve_data_mode(cfg, verbose=not hpo_mode)
-    data_points_full, has_data_loss, data_free = load_training_data(
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
         verbose=not hpo_mode,
     )
 

--- a/experiments/experiment_3/train.py
+++ b/experiments/experiment_3/train.py
@@ -149,14 +149,14 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
         verbose=not hpo_mode,
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
         verbose=not hpo_mode,
     )
     validation_data_loaded = validation["loaded"]

--- a/experiments/experiment_4/train.py
+++ b/experiments/experiment_4/train.py
@@ -43,7 +43,7 @@ from src.training import (
     get_sampling_count_from_config,
     get_boundary_segment_count,
     init_model_from_config,
-    load_training_data,
+    resolve_training_data,
     load_validation_from_file,
     train_step_jitted,
     make_scan_body,
@@ -142,11 +142,11 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
     # --- Load Validation and Training Data ---
     data_points_full = None
     data_free, has_data_loss = resolve_data_mode(cfg)
-    data_points_full, has_data_loss, data_free = load_training_data(
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)

--- a/experiments/experiment_4/train.py
+++ b/experiments/experiment_4/train.py
@@ -146,13 +146,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_5/train.py
+++ b/experiments/experiment_5/train.py
@@ -140,13 +140,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_5/train.py
+++ b/experiments/experiment_5/train.py
@@ -41,7 +41,7 @@ from src.training import (
     get_sampling_count_from_config,
     get_boundary_segment_count,
     init_model_from_config,
-    load_training_data,
+    resolve_training_data,
     load_validation_from_file,
     train_step_jitted,
     make_scan_body,
@@ -136,11 +136,11 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
     # --- Load Validation and Training Data ---
     data_points_full = None
     data_free, has_data_loss = resolve_data_mode(cfg)
-    data_points_full, has_data_loss, data_free = load_training_data(
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)

--- a/experiments/experiment_6/train.py
+++ b/experiments/experiment_6/train.py
@@ -137,13 +137,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_6/train.py
+++ b/experiments/experiment_6/train.py
@@ -42,7 +42,7 @@ from src.training import (
     get_sampling_count_from_config,
     get_boundary_segment_count,
     init_model_from_config,
-    load_training_data,
+    resolve_training_data,
     load_validation_from_file,
     train_step_jitted,
     make_scan_body,
@@ -133,11 +133,11 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
     # --- Load Validation and Training Data ---
     data_points_full = None
     data_free, has_data_loss = resolve_data_mode(cfg)
-    data_points_full, has_data_loss, data_free = load_training_data(
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # C. Load Validation Data (Optional)

--- a/experiments/experiment_7/train.py
+++ b/experiments/experiment_7/train.py
@@ -174,13 +174,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # E. Load Validation Data (Optional)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_7/train.py
+++ b/experiments/experiment_7/train.py
@@ -44,7 +44,7 @@ from src.training import (
     get_experiment_name,
     get_sampling_count_from_config,
     init_model_from_config,
-    load_training_data,
+    resolve_training_data,
     load_validation_from_file,
     train_step_jitted,
     make_scan_body,
@@ -170,11 +170,11 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
     # D. Load Validation and Training Data
     data_points_full = None
     data_free, has_data_loss = resolve_data_mode(cfg)
-    data_points_full, has_data_loss, data_free = load_training_data(
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # E. Load Validation Data (Optional)

--- a/experiments/experiment_8/train.py
+++ b/experiments/experiment_8/train.py
@@ -47,7 +47,7 @@ from src.training import (
     get_experiment_name,
     get_sampling_count_from_config,
     init_model_from_config,
-    load_training_data,
+    resolve_training_data,
     load_validation_from_file,
     train_step_jitted,
     make_scan_body,
@@ -176,11 +176,11 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
     data_points_full = None
 
     data_free, has_data_loss = resolve_data_mode(cfg)
-    data_points_full, has_data_loss, data_free = load_training_data(
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # E. Load Validation Data (Ground Truth)

--- a/experiments/experiment_8/train.py
+++ b/experiments/experiment_8/train.py
@@ -180,13 +180,13 @@ def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
         base_data_path,
         has_data_loss,
         static_weights_dict,
-        filename=get_data_filename(cfg, "training_file", "training_dataset_sample.npy"),
+        filename=get_data_filename(cfg, "training_file", "train_lhs_points.npy"),
     )
 
     # E. Load Validation Data (Ground Truth)
     validation = load_validation_from_file(
         base_data_path,
-        get_data_filename(cfg, "validation_file", "validation_gauges_ground_truth.npy"),
+        get_data_filename(cfg, "validation_file", "val_gauges_gt.npy"),
     )
     validation_data_loaded = validation["loaded"]
     full_val_data = validation["full_val_data"]

--- a/experiments/experiment_8/train_imp_samp.py
+++ b/experiments/experiment_8/train_imp_samp.py
@@ -286,7 +286,7 @@ def main(config_path: str):
     data_free_flag = cfg.get("data_free")
     has_data_loss = not data_free_flag
     
-    training_data_file = os.path.join(base_data_path, "training_dataset_sample.npy")
+    training_data_file = os.path.join(base_data_path, "train_lhs_points.npy")
     if has_data_loss: 
         if os.path.exists(training_data_file):
             try:
@@ -301,7 +301,7 @@ def main(config_path: str):
             has_data_loss = False
     data_free = not has_data_loss 
 
-    validation_data_file = os.path.join(base_data_path, "validation_gauges_ground_truth.npy")
+    validation_data_file = os.path.join(base_data_path, "val_gauges_gt.npy")
     validation_data_loaded = False
     val_pts_batch = None
     val_h_true = None

--- a/experiments/experiment_8/train_imp_samp.py
+++ b/experiments/experiment_8/train_imp_samp.py
@@ -56,7 +56,7 @@ from src.utils import (
 )
 from src.monitoring import ConsoleLogger, WandbTracker, compute_negative_depth_diagnostics
 from src.checkpointing import CheckpointManager
-from src.training import train_step_jitted, make_scan_body, maybe_batch_data
+from src.training import train_step_jitted, make_scan_body, maybe_batch_data, resolve_training_data
 
 from src.physics import SWEPhysics
 from src.balancing.importance_sampling import (
@@ -281,25 +281,16 @@ def main(config_path: str):
     bc_fn_static = load_boundary_condition(bc_csv_path)
 
     val_points, h_true_val = None, None
-    data_points_full = None
-    
+
     data_free_flag = cfg.get("data_free")
     has_data_loss = not data_free_flag
-    
-    training_data_file = os.path.join(base_data_path, "train_lhs_points.npy")
-    if has_data_loss: 
-        if os.path.exists(training_data_file):
-            try:
-                data_points_full = jnp.load(training_data_file).astype(get_dtype()) 
-                if data_points_full.shape[0] == 0:
-                     data_points_full = None
-                     has_data_loss = False
-            except Exception as e:
-                data_points_full = None
-                has_data_loss = False
-        else:
-            has_data_loss = False
-    data_free = not has_data_loss 
+
+    data_points_full, has_data_loss, data_free = resolve_training_data(
+        cfg,
+        base_data_path,
+        has_data_loss,
+        static_weights_dict,
+    )
 
     validation_data_file = os.path.join(base_data_path, "val_gauges_gt.npy")
     validation_data_loaded = False

--- a/optimisation/configs/exploration/hpo_dgm_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_dgm_experiment_3.yaml
@@ -14,8 +14,8 @@ experiment:
 
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 training:
   epochs: 500

--- a/optimisation/configs/exploration/hpo_dgm_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_dgm_experiment_3.yaml
@@ -14,6 +14,8 @@ experiment:
 
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/optimisation/configs/exploration/hpo_fourier_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_fourier_experiment_3.yaml
@@ -14,8 +14,8 @@ experiment:
 
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 training:
   epochs: 500

--- a/optimisation/configs/exploration/hpo_fourier_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_fourier_experiment_3.yaml
@@ -14,6 +14,8 @@ experiment:
 
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/optimisation/configs/exploration/hpo_mlp_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_mlp_experiment_3.yaml
@@ -14,8 +14,8 @@ experiment:
 
 data:
   root_dir: data
-  training_file: training_dataset_sample.npy
-  validation_file: validation_gauges.npy
+  training_file: train_lhs_points.npy
+  validation_file: val_gauges_gt.npy
 
 training:
   epochs: 500

--- a/optimisation/configs/exploration/hpo_mlp_experiment_3.yaml
+++ b/optimisation/configs/exploration/hpo_mlp_experiment_3.yaml
@@ -14,6 +14,8 @@ experiment:
 
 data:
   root_dir: data
+  source_file: val_full_domain.npy
+  n_train_samples: 2000
   training_file: train_lhs_points.npy
   validation_file: val_gauges_gt.npy
 

--- a/scripts/binary_to_numpy.py
+++ b/scripts/binary_to_numpy.py
@@ -2,14 +2,14 @@
 
 This is stage 2 of the preprocessing pipeline:
   1. InfoWorks ICM CSV -> binary (cpp/preprocess.cpp via run_preprocess.sh)
-  2. Binary -> .npy (this script)
-  3. .npy tensor -> training/validation/plotting datasets (generate_training_data.py)
+  2. Binary -> .npy (this script): val_full_domain.bin -> val_full_domain.npy
+  3. .npy -> training/validation datasets (generate_training_data.py or src/data/loader.py)
 
 The binary file contains rows of 6 float64 values: [t, x, y, h, u, v].
 Output is saved as float32 to reduce file size.
 
 Usage:
-    python binary_to_numpy.py input.bin output.npy
+    python binary_to_numpy.py val_full_domain.bin val_full_domain.npy
 """
 import numpy as np
 import argparse

--- a/scripts/filter_by_time.py
+++ b/scripts/filter_by_time.py
@@ -4,7 +4,7 @@ Reads a .npy file where the first column is time (t), keeps only rows where
 t <= max_time, and saves the filtered result to a new file.
 
 Usage:
-    python filter_by_time.py validation_sample.npy --max_time 3600
+    python filter_by_time.py val_lhs_points.npy --max_time 3600
 """
 import numpy as np
 import os
@@ -13,12 +13,12 @@ from pathlib import Path
 
 def filter_validation_sample_by_time(input_npy_path: str, max_time: float = 3600.0) -> None:
     """
-    Loads a validation_sample.npy file, filters it to keep rows where
+    Loads a val_lhs_points.npy file, filters it to keep rows where
     time (first column) is less than or equal to max_time, and saves
     the filtered data to a new file in the same directory.
 
     Args:
-        input_npy_path (str): Path to the input validation_sample.npy file.
+        input_npy_path (str): Path to the input val_lhs_points.npy file.
         max_time (float): The maximum time value (inclusive) to keep.
                           Defaults to 3600.0.
     """
@@ -62,12 +62,12 @@ def filter_validation_sample_by_time(input_npy_path: str, max_time: float = 3600
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description=f"Filter a validation_sample.npy file based on a maximum time value."
+        description=f"Filter a val_lhs_points.npy file based on a maximum time value."
     )
     parser.add_argument(
         "input_file",
         type=str,
-        help="Path to the input validation_sample.npy file."
+        help="Path to the input val_lhs_points.npy file."
     )
     parser.add_argument(
         "--max_time",
@@ -79,11 +79,11 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # --- Example Usage ---
-    # Assuming your file is in 'data/one_building_DEM_zero/validation_sample.npy'
+    # Assuming your file is in 'data/one_building_DEM_zero/val_lhs_points.npy'
     # You would run this script like:
-    # python <script_name>.py data/one_building_DEM_zero/validation_sample.npy --max_time 3600.0
+    # python <script_name>.py data/one_building_DEM_zero/val_lhs_points.npy --max_time 3600.0
     # Or simply:
-    # python <script_name>.py data/one_building_DEM_zero/validation_sample.npy
+    # python <script_name>.py data/one_building_DEM_zero/val_lhs_points.npy
     # (since 3600.0 is the default max_time)
 
     filter_validation_sample_by_time(args.input_file, args.max_time)

--- a/scripts/generate_training_data.py
+++ b/scripts/generate_training_data.py
@@ -61,16 +61,16 @@ def create_datasets(
 
     # --- 1. Define File Paths ---
     base_path = Path('data') / scenario_name
-    input_file = base_path / 'validation_tensor.npy'
-    val_sample_file = base_path / 'validation_sample.npy'
-    train_sample_file = base_path / 'training_dataset_sample.npy'
+    input_file = base_path / 'val_full_domain.npy'
+    val_sample_file = base_path / 'val_lhs_points.npy'
+    train_sample_file = base_path / 'train_lhs_points.npy'
     plot_file = base_path / f'validation_plotting_t_{int(plotting_time)}s.npy'
 
     if not base_path.exists():
         print(f"Error: Scenario directory not found at {base_path}")
         return
     if not input_file.exists():
-        print(f"Error: Input file validation_tensor.npy not found at {input_file}")
+        print(f"Error: Input file val_full_domain.npy not found at {input_file}")
         return
 
     print(f"Input tensor: {input_file}")

--- a/scripts/process_gauge_csvs.py
+++ b/scripts/process_gauge_csvs.py
@@ -21,13 +21,13 @@ Column conventions:
 
 Usage:
     # Merged mode (single output)
-    python process_gauge_csvs.py --meta meta.csv --depth depth.csv \\
-        --angle angle.csv --speed speed.csv --output gauges.npy
+    python process_gauge_csvs.py --meta gauge_metadata.csv --depth gauge_depth.csv \\
+        --angle gauge_angle.csv --speed gauge_speed.csv --output gauge_data.npy
 
     # Split mode (train/val outputs)
-    python process_gauge_csvs.py --meta meta.csv --depth depth.csv \\
-        --angle angle.csv --speed speed.csv --split \\
-        --output_train train.npy --output_val val.npy
+    python process_gauge_csvs.py --meta gauge_metadata.csv --depth gauge_depth.csv \\
+        --angle gauge_angle.csv --speed gauge_speed.csv --split \\
+        --output_train train_gauges.npy --output_val val_gauges_gt.npy
 """
 
 import pandas as pd

--- a/scripts/regenerate_validation_data.sh
+++ b/scripts/regenerate_validation_data.sh
@@ -5,7 +5,7 @@
 # the training loop can compute NSE/RMSE for hu and hv in addition to h.
 #
 # Prerequisites:
-#   - Raw ICM simulation data must exist as validation_tensor.npy (6 columns)
+#   - Raw ICM simulation data must exist as val_full_domain.npy (6 columns)
 #     under data/experiment_N/. If only 4-column tensors exist, re-run the
 #     full pipeline from ICM CSV -> binary -> .npy first.
 #   - For gauge-based experiments (3-7), the gauge CSVs (depth, angle, speed)
@@ -50,10 +50,10 @@ echo "  val_samples=$VAL_SAMPLES  train_samples=$TRAIN_SAMPLES  max_time=$MAX_TI
 echo ""
 
 # --- Experiment 2: Building obstacle ---
-# Uses generate_training_data.py which samples from validation_tensor.npy
-EXP2_TENSOR="$PROJECT_ROOT/data/experiment_2/validation_tensor.npy"
+# Uses generate_training_data.py which samples from val_full_domain.npy
+EXP2_TENSOR="$PROJECT_ROOT/data/experiment_2/val_full_domain.npy"
 if [ -f "$EXP2_TENSOR" ]; then
-    echo "[Experiment 2] Regenerating from validation_tensor.npy..."
+    echo "[Experiment 2] Regenerating from val_full_domain.npy..."
     python "$SCRIPT_DIR/generate_training_data.py" \
         --scenario experiment_2 \
         --val_samples "$VAL_SAMPLES" \
@@ -96,14 +96,14 @@ for exp_num in 3 4 5 6 7; do
                 --speed "$SPEED_FILE" \
                 --split \
                 --output_train "$EXP_DIR/training_gauges.npy" \
-                --output_val "$EXP_DIR/validation_gauges.npy"
+                --output_val "$EXP_DIR/val_gauges_gt.npy"
             echo "[Experiment $exp_num] Done."
         else
             echo "[Experiment $exp_num] SKIP: Missing gauge CSV files in $EXP_DIR."
             echo "  Need: *_depth.csv, *_angle.csv, and *_speed.csv."
         fi
-    elif [ -f "$EXP_DIR/validation_tensor.npy" ]; then
-        echo "[Experiment $exp_num] Regenerating from validation_tensor.npy..."
+    elif [ -f "$EXP_DIR/val_full_domain.npy" ]; then
+        echo "[Experiment $exp_num] Regenerating from val_full_domain.npy..."
         python "$SCRIPT_DIR/generate_training_data.py" \
             --scenario "experiment_${exp_num}" \
             --val_samples "$VAL_SAMPLES" \
@@ -119,6 +119,6 @@ done
 echo "=== Validation data regeneration complete ==="
 echo ""
 echo "Verify column counts with:"
-echo "  python -c \"import numpy as np; d=np.load('data/experiment_N/validation_sample.npy'); print(d.shape)\""
+echo "  python -c \"import numpy as np; d=np.load('data/experiment_N/val_lhs_points.npy'); print(d.shape)\""
 echo ""
 echo "Expected: (N, 6) with columns [t, x, y, h, u, v]"

--- a/scripts/regenerate_validation_data.sh
+++ b/scripts/regenerate_validation_data.sh
@@ -96,7 +96,7 @@ for exp_num in 3 4 5 6 7; do
                 --angle "$ANGLE_FILE" \
                 --speed "$SPEED_FILE" \
                 --split \
-                --output_train "$EXP_DIR/training_gauges.npy" \
+                --output_train "$EXP_DIR/train_gauges.npy" \
                 --output_val "$EXP_DIR/val_gauges_gt.npy"
             echo "[Experiment $exp_num] Done."
         else

--- a/scripts/regenerate_validation_data.sh
+++ b/scripts/regenerate_validation_data.sh
@@ -8,8 +8,8 @@
 #   - Raw ICM simulation data must exist as val_full_domain.npy (6 columns)
 #     under data/experiment_N/. If only 4-column tensors exist, re-run the
 #     full pipeline from ICM CSV -> binary -> .npy first.
-#   - For gauge-based experiments (3-7), the gauge CSVs (depth, angle, speed)
-#     and metadata CSV must be available.
+#   - For gauge-based experiments (3-7), gauge CSVs (gauge_depth.csv,
+#     gauge_angle.csv, gauge_speed.csv) and gauge_metadata.csv must exist.
 #
 # This script is a convenience wrapper. See individual scripts for options.
 #
@@ -77,12 +77,13 @@ for exp_num in 3 4 5 6 7; do
     META_FILE="$EXP_DIR/gauge_metadata.csv"
 
     if [ -f "$META_FILE" ]; then
-        # Look for gauge CSVs with specific naming patterns.
-        # Only match files directly named *_depth.csv, *_angle.csv, *_speed.csv
-        # to avoid false positives on backup or config files.
-        DEPTH_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_depth.csv" -o -name "depth_*.csv" 2>/dev/null | head -1)
-        ANGLE_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_angle.csv" -o -name "angle_*.csv" 2>/dev/null | head -1)
-        SPEED_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_speed.csv" -o -name "speed_*.csv" 2>/dev/null | head -1)
+        # Look for gauge CSVs: prefer canonical names, fall back to glob.
+        DEPTH_FILE="$EXP_DIR/gauge_depth.csv"
+        ANGLE_FILE="$EXP_DIR/gauge_angle.csv"
+        SPEED_FILE="$EXP_DIR/gauge_speed.csv"
+        [ -f "$DEPTH_FILE" ] || DEPTH_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_depth.csv" -o -name "depth_*.csv" 2>/dev/null | head -1)
+        [ -f "$ANGLE_FILE" ] || ANGLE_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_angle.csv" -o -name "angle_*.csv" 2>/dev/null | head -1)
+        [ -f "$SPEED_FILE" ] || SPEED_FILE=$(find "$EXP_DIR" -maxdepth 1 -name "*_speed.csv" -o -name "speed_*.csv" 2>/dev/null | head -1)
 
         if [ -n "$DEPTH_FILE" ] && [ -n "$ANGLE_FILE" ] && [ -n "$SPEED_FILE" ]; then
             echo "[Experiment $exp_num] Regenerating from gauge CSVs..."

--- a/scripts/run_preprocess.sh
+++ b/scripts/run_preprocess.sh
@@ -20,6 +20,10 @@ set -e  # Exit immediately if a command exits with a non-zero status
 #
 # Usage:
 #   ./run_preprocess.sh <angle_csv> <depth_csv> <speed_csv> <output_bin>
+#
+# CSV naming convention:
+#   Full domain exports:  full_domain_angle.csv, full_domain_depth.csv, full_domain_speed.csv
+#   Gauge sensor exports: gauge_angle.csv, gauge_depth.csv, gauge_speed.csv
 # =============================================================================
 
 # 1. Define where the C++ source code now lives

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -2,6 +2,7 @@
 from src.data.sampling import sample_points, sample_domain, sample_lhs
 from src.data.batching import get_batches, get_batches_tensor, get_sample_count
 from src.data.loading import load_validation_data, load_boundary_condition
+from src.data.loader import sample_training_data, resolve_training_data
 from src.data.bathymetry import load_bathymetry, bathymetry_fn, get_bathymetry_fn, reset_bathymetry
 from src.data.irregular import (
     IrregularDomainSampler,

--- a/src/data/loader.py
+++ b/src/data/loader.py
@@ -1,0 +1,211 @@
+"""Config-driven data loading with LHS subsampling for training.
+
+Replaces the pre-baked ``generate_training_data.py`` workflow.  Instead of
+creating a fixed-size ``train_lhs_points.npy`` offline, this module loads the
+full domain file at startup, selects ``n_train_samples`` points via Latin
+Hypercube Sampling, and immediately frees the large source array.
+"""
+import gc
+import os
+from typing import Optional
+
+import numpy as np
+import jax.numpy as jnp
+
+from src.config import get_dtype
+
+
+def sample_training_data(
+    source_path: str,
+    n_samples: int,
+    seed: int = 42,
+    max_time: Optional[float] = None,
+    verbose: bool = True,
+) -> jnp.ndarray:
+    """Load a full-domain data file and return an LHS subsample.
+
+    Parameters
+    ----------
+    source_path : str
+        Path to the full spatiotemporal field (``.npy``, columns
+        ``[t, x, y, h, u, v]``).
+    n_samples : int
+        Number of points to select via Latin Hypercube Sampling.
+    seed : int
+        Random seed for reproducibility.
+    max_time : float, optional
+        If given, only rows with ``t <= max_time`` are eligible for sampling.
+    verbose : bool
+        Print progress messages.
+
+    Returns
+    -------
+    jnp.ndarray, shape (n_samples, 6)
+        Subsampled data in ``[t, x, y, h, u, v]`` format.
+    """
+    if verbose:
+        print(f"Loading source data from: {source_path}")
+    raw = np.load(source_path)
+    if verbose:
+        print(f"  Source shape: {raw.shape} ({raw.nbytes / 1e6:.1f} MB)")
+
+    # Optional time filter
+    if max_time is not None:
+        mask = raw[:, 0] <= max_time
+        raw = raw[mask]
+        if verbose:
+            print(f"  After time filter (t <= {max_time}): {raw.shape[0]} rows")
+
+    n_available = raw.shape[0]
+    if n_samples >= n_available:
+        if verbose:
+            print(f"  Requested {n_samples} samples but only {n_available} available. Using all.")
+        result = jnp.array(raw, dtype=get_dtype())
+        del raw
+        gc.collect()
+        return result
+
+    # Latin Hypercube Sampling: stratified index selection
+    indices = _lhs_indices(n_available, n_samples, seed)
+    sample = raw[indices]
+
+    # Free the large source array
+    del raw
+    gc.collect()
+
+    result = jnp.array(sample, dtype=get_dtype())
+    if verbose:
+        print(f"  LHS sampled {n_samples} / {n_available} points (seed={seed})")
+    return result
+
+
+def _lhs_indices(n_total: int, n_samples: int, seed: int) -> np.ndarray:
+    """Select indices via 1-D Latin Hypercube Sampling.
+
+    Divides the index range ``[0, n_total)`` into ``n_samples`` equal strata
+    and picks one random index per stratum.  This ensures even coverage across
+    the dataset regardless of its internal ordering.
+    """
+    rng = np.random.default_rng(seed)
+    strata = np.linspace(0, n_total, n_samples + 1, dtype=np.float64)
+    lo = strata[:-1].astype(np.intp)
+    hi = np.clip(strata[1:].astype(np.intp), lo + 1, n_total)
+    return rng.integers(lo, hi)
+
+
+def resolve_training_data(
+    cfg,
+    base_data_path: str,
+    has_data_loss: bool,
+    static_weights_dict: dict,
+    *,
+    verbose: bool = True,
+):
+    """Config-driven training data resolution.
+
+    Tries the LHS-from-source path first (``data.source_file`` +
+    ``data.n_train_samples``).  Falls back to loading a pre-sampled file
+    (``data.training_file`` or default ``train_lhs_points.npy``).
+
+    Parameters
+    ----------
+    cfg : dict or FrozenDict
+        Experiment configuration.
+    base_data_path : str
+        Root path to the experiment's data directory.
+    has_data_loss : bool
+        Whether data-driven loss is active.
+    static_weights_dict : dict
+        Loss weight dict (used for informational logging only).
+    verbose : bool
+        Print progress messages.
+
+    Returns
+    -------
+    tuple of (data_points_full, has_data_loss, data_free)
+    """
+    data_points_full = None
+
+    if not has_data_loss:
+        return None, False, True
+
+    data_cfg = cfg.get("data", {})
+    source_file = data_cfg.get("source_file")
+    n_train_samples = data_cfg.get("n_train_samples")
+    training_seed = cfg.get("training", {}).get("seed", 42)
+    max_time = data_cfg.get("train_max_time")
+
+    # --- Path 1: LHS from full-domain source file ---
+    if source_file and n_train_samples:
+        source_path = os.path.join(base_data_path, source_file)
+        if os.path.exists(source_path):
+            try:
+                data_points_full = sample_training_data(
+                    source_path,
+                    n_train_samples,
+                    seed=training_seed,
+                    max_time=max_time,
+                    verbose=verbose,
+                )
+                if verbose:
+                    data_weight = static_weights_dict.get("data", 0.0)
+                    print(
+                        f"Using {data_points_full.shape[0]} LHS-sampled points "
+                        f"for data loss term (weight={data_weight:.2e})."
+                    )
+                    if data_weight == 0.0:
+                        print(
+                            "Warning: 'data_free: false' but 'data_weight' is 0. "
+                            "Data will be loaded but loss term will be 0."
+                        )
+                return data_points_full, True, False
+            except Exception as e:
+                if verbose:
+                    print(f"Error sampling from source file {source_path}: {e}")
+                    print("Falling back to pre-sampled training file.")
+        elif verbose:
+            print(
+                f"Source file not found at {source_path}. "
+                "Falling back to pre-sampled training file."
+            )
+
+    # --- Path 2: Load pre-sampled file (backward compatible) ---
+    fallback_filename = data_cfg.get("training_file", "train_lhs_points.npy")
+    training_data_file = os.path.join(base_data_path, fallback_filename)
+
+    if os.path.exists(training_data_file):
+        try:
+            if verbose:
+                print(f"Loading TRAINING data from: {training_data_file}")
+            data_points_full = jnp.load(training_data_file).astype(get_dtype())
+            if data_points_full.shape[0] == 0:
+                if verbose:
+                    print("Warning: Training data file is empty. Disabling data loss.")
+                data_points_full = None
+                has_data_loss = False
+            else:
+                if verbose:
+                    data_weight = static_weights_dict.get("data", 0.0)
+                    print(
+                        f"Using {data_points_full.shape[0]} points for data loss "
+                        f"term (weight={data_weight:.2e})."
+                    )
+                    if data_weight == 0.0:
+                        print(
+                            "Warning: 'data_free: false' but 'data_weight' is 0. "
+                            "Data will be loaded but loss term will be 0."
+                        )
+        except Exception as e:
+            if verbose:
+                print(f"Error loading training data file {training_data_file}: {e}")
+                print("Disabling data loss term due to loading error.")
+            data_points_full = None
+            has_data_loss = False
+    else:
+        if verbose:
+            print(f"Warning: Training data file not found at {training_data_file}.")
+            print("Data loss term cannot be computed and will be disabled.")
+        has_data_loss = False
+
+    data_free = not has_data_loss
+    return data_points_full, has_data_loss, data_free

--- a/src/inference/experiment_registry.py
+++ b/src/inference/experiment_registry.py
@@ -39,7 +39,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_5": {
         "domain_type": "rectangular",
@@ -48,7 +48,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": ["overtopping"],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_6": {
         "domain_type": "rectangular",
@@ -57,7 +57,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_7": {
         "domain_type": "irregular",
@@ -66,7 +66,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_8": {
         "domain_type": "irregular",
@@ -75,7 +75,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": ["per_building_slip", "street_corridor"],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
 }
 
@@ -89,5 +89,5 @@ def get_experiment_meta(experiment_name: str) -> dict:
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "val_lhs_points.npy",
+        "default_val_file": "val_gauges_gt.npy",
     })

--- a/src/inference/experiment_registry.py
+++ b/src/inference/experiment_registry.py
@@ -21,7 +21,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": ["building_split"],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_3": {
         "domain_type": "rectangular",
@@ -30,7 +30,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_gauges.npy",
+        "default_val_file": "val_gauges_gt.npy",
     },
     "experiment_4": {
         "domain_type": "rectangular",
@@ -39,7 +39,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_5": {
         "domain_type": "rectangular",
@@ -48,7 +48,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": ["overtopping"],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_6": {
         "domain_type": "rectangular",
@@ -57,7 +57,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_7": {
         "domain_type": "irregular",
@@ -66,7 +66,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
     "experiment_8": {
         "domain_type": "irregular",
@@ -75,7 +75,7 @@ EXPERIMENT_REGISTRY = {
         "reference_type": "simulation",
         "flood_extent": True,
         "extra_checks": ["per_building_slip", "street_corridor"],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     },
 }
 
@@ -89,5 +89,5 @@ def get_experiment_meta(experiment_name: str) -> dict:
         "reference_type": "simulation",
         "flood_extent": False,
         "extra_checks": [],
-        "default_val_file": "validation_sample.npy",
+        "default_val_file": "val_lhs_points.npy",
     })

--- a/src/inference/runner.py
+++ b/src/inference/runner.py
@@ -57,7 +57,7 @@ def _load_validation(cfg_dict, paths_info, meta, experiment_name):
         return _generate_analytical_validation(cfg_dict)
 
     val_file = get_data_filename(cfg_dict, "validation_file",
-                                 meta.get("default_val_file", "validation_sample.npy"))
+                                 meta.get("default_val_file", "val_lhs_points.npy"))
     val_path = os.path.join(paths_info["base_data_path"], val_file)
 
     if not os.path.exists(val_path):

--- a/src/training/__init__.py
+++ b/src/training/__init__.py
@@ -16,7 +16,7 @@ from src.training.setup import (
 	apply_output_scales,
 )
 from src.training.optimizer import create_optimizer
-from src.training.data_loading import resolve_data_mode, load_training_data, load_validation_from_file, load_terrain_assets
+from src.training.data_loading import resolve_data_mode, load_training_data, resolve_training_data, load_validation_from_file, load_terrain_assets
 from src.training.loop import run_training_loop, post_training_save
 from src.training.step import train_step, train_step_jitted
 from src.training.epoch import (

--- a/src/training/data_loading.py
+++ b/src/training/data_loading.py
@@ -34,7 +34,7 @@ def resolve_data_mode(cfg, verbose=True):
 
 
 def load_training_data(base_data_path, has_data_loss, static_weights_dict,
-                       filename="training_dataset_sample.npy", verbose=True):
+                       filename="train_lhs_points.npy", verbose=True):
     """Load the training data .npy file if data-driven mode is active.
 
     Returns
@@ -79,7 +79,7 @@ def load_training_data(base_data_path, has_data_loss, static_weights_dict,
     return data_points_full, has_data_loss, data_free
 
 
-def load_validation_from_file(base_data_path, filename="validation_gauges.npy", verbose=True):
+def load_validation_from_file(base_data_path, filename="val_gauges_gt.npy", verbose=True):
     """Load validation gauge data if it exists.
 
     Returns

--- a/src/training/data_loading.py
+++ b/src/training/data_loading.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 
 from src.config import get_dtype
 from src.data import load_validation_data, load_bathymetry, load_boundary_condition
+from src.data.loader import resolve_training_data  # noqa: F401 — re-exported
 from src.training.setup import resolve_configured_asset_path
 
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -1,0 +1,227 @@
+"""Tests for src.data.loader — LHS sampling and config-driven data resolution."""
+import os
+import shutil
+import tempfile
+import unittest
+
+os.environ["JAX_PLATFORM_NAME"] = "cpu"
+
+import numpy as np
+import jax.numpy as jnp
+
+from src.config import load_config
+from src.data.loader import _lhs_indices, sample_training_data, resolve_training_data
+
+
+class TestLhsIndices(unittest.TestCase):
+    """Unit tests for the stratified index selection helper."""
+
+    def test_returns_correct_count(self):
+        indices = _lhs_indices(10000, 100, seed=0)
+        self.assertEqual(len(indices), 100)
+
+    def test_indices_within_bounds(self):
+        n_total = 5000
+        indices = _lhs_indices(n_total, 200, seed=42)
+        self.assertTrue(np.all(indices >= 0))
+        self.assertTrue(np.all(indices < n_total))
+
+    def test_indices_are_sorted_approximately(self):
+        """Stratified sampling should produce roughly monotonic indices."""
+        indices = _lhs_indices(100000, 500, seed=7)
+        # At least 90% of consecutive pairs should be increasing
+        increasing = np.sum(np.diff(indices) > 0)
+        self.assertGreater(increasing / (len(indices) - 1), 0.9)
+
+    def test_no_duplicates_for_large_pool(self):
+        indices = _lhs_indices(100000, 1000, seed=99)
+        self.assertEqual(len(np.unique(indices)), len(indices))
+
+    def test_deterministic_with_same_seed(self):
+        a = _lhs_indices(10000, 50, seed=123)
+        b = _lhs_indices(10000, 50, seed=123)
+        np.testing.assert_array_equal(a, b)
+
+    def test_different_seed_gives_different_result(self):
+        a = _lhs_indices(10000, 50, seed=1)
+        b = _lhs_indices(10000, 50, seed=2)
+        self.assertFalse(np.array_equal(a, b))
+
+    def test_edge_case_n_samples_equals_n_total(self):
+        """When requesting as many samples as available, all indices should be covered."""
+        indices = _lhs_indices(10, 10, seed=0)
+        self.assertEqual(len(indices), 10)
+        self.assertTrue(np.all(indices >= 0))
+        self.assertTrue(np.all(indices < 10))
+
+    def test_single_sample(self):
+        indices = _lhs_indices(1000, 1, seed=0)
+        self.assertEqual(len(indices), 1)
+        self.assertTrue(0 <= indices[0] < 1000)
+
+
+class TestSampleTrainingData(unittest.TestCase):
+    """Tests for the full load-sample-free pipeline."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="test_loader_")
+        # Create a mock full-domain .npy with 1000 rows, 6 columns [t, x, y, h, u, v]
+        rng = np.random.default_rng(42)
+        self.n_rows = 1000
+        self.data = np.zeros((self.n_rows, 6), dtype=np.float32)
+        self.data[:, 0] = np.linspace(0, 3600, self.n_rows)  # t
+        self.data[:, 1] = rng.uniform(0, 100, self.n_rows)   # x
+        self.data[:, 2] = rng.uniform(0, 50, self.n_rows)    # y
+        self.data[:, 3] = rng.uniform(0, 2, self.n_rows)     # h
+        self.data[:, 4] = rng.uniform(-0.5, 0.5, self.n_rows)  # u
+        self.data[:, 5] = rng.uniform(-0.5, 0.5, self.n_rows)  # v
+        self.source_path = os.path.join(self.test_dir, "val_full_domain.npy")
+        np.save(self.source_path, self.data)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_returns_correct_shape(self):
+        result = sample_training_data(self.source_path, 50, seed=0, verbose=False)
+        self.assertEqual(result.shape, (50, 6))
+
+    def test_returns_jax_array(self):
+        result = sample_training_data(self.source_path, 10, seed=0, verbose=False)
+        self.assertIsInstance(result, jnp.ndarray)
+
+    def test_returns_correct_dtype(self):
+        result = sample_training_data(self.source_path, 10, seed=0, verbose=False)
+        self.assertEqual(result.dtype, jnp.float32)
+
+    def test_values_come_from_source(self):
+        """Sampled values should all exist in the original data."""
+        result = sample_training_data(self.source_path, 20, seed=0, verbose=False)
+        result_np = np.array(result)
+        for row in result_np:
+            # Check that this t value exists in the source
+            matches = np.isclose(self.data[:, 0], row[0], atol=1e-5)
+            self.assertTrue(np.any(matches), f"t={row[0]} not found in source")
+
+    def test_max_time_filter(self):
+        """With max_time=1800, no sampled point should have t > 1800."""
+        result = sample_training_data(
+            self.source_path, 50, seed=0, max_time=1800.0, verbose=False
+        )
+        self.assertTrue(np.all(np.array(result[:, 0]) <= 1800.0))
+
+    def test_request_more_than_available(self):
+        """Requesting more samples than rows should return all rows."""
+        result = sample_training_data(
+            self.source_path, self.n_rows + 500, seed=0, verbose=False
+        )
+        self.assertEqual(result.shape[0], self.n_rows)
+
+    def test_deterministic(self):
+        a = sample_training_data(self.source_path, 30, seed=7, verbose=False)
+        b = sample_training_data(self.source_path, 30, seed=7, verbose=False)
+        np.testing.assert_array_equal(np.array(a), np.array(b))
+
+
+class TestResolveTrainingData(unittest.TestCase):
+    """Tests for the config-driven resolver with source file and fallback paths."""
+
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp(prefix="test_resolve_")
+        # Create source file
+        rng = np.random.default_rng(0)
+        self.source_data = rng.random((500, 6)).astype(np.float32)
+        np.save(os.path.join(self.test_dir, "val_full_domain.npy"), self.source_data)
+        # Create fallback file (smaller)
+        self.fallback_data = rng.random((100, 6)).astype(np.float32)
+        np.save(os.path.join(self.test_dir, "train_lhs_points.npy"), self.fallback_data)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_lhs_path_when_source_exists(self):
+        cfg = {
+            "data": {
+                "source_file": "val_full_domain.npy",
+                "n_train_samples": 50,
+                "training_file": "train_lhs_points.npy",
+            },
+            "training": {"seed": 42},
+        }
+        result, has_data, data_free = resolve_training_data(
+            cfg, self.test_dir, True, {"data": 1.0}, verbose=False
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.shape, (50, 6))
+        self.assertTrue(has_data)
+        self.assertFalse(data_free)
+
+    def test_fallback_when_source_missing(self):
+        cfg = {
+            "data": {
+                "source_file": "nonexistent.npy",
+                "n_train_samples": 50,
+                "training_file": "train_lhs_points.npy",
+            },
+            "training": {"seed": 42},
+        }
+        result, has_data, data_free = resolve_training_data(
+            cfg, self.test_dir, True, {"data": 1.0}, verbose=False
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.shape[0], 100)  # fallback file has 100 rows
+        self.assertTrue(has_data)
+        self.assertFalse(data_free)
+
+    def test_fallback_when_no_source_configured(self):
+        cfg = {
+            "data": {
+                "training_file": "train_lhs_points.npy",
+            },
+        }
+        result, has_data, data_free = resolve_training_data(
+            cfg, self.test_dir, True, {"data": 1.0}, verbose=False
+        )
+        self.assertIsNotNone(result)
+        self.assertEqual(result.shape[0], 100)
+        self.assertTrue(has_data)
+
+    def test_returns_none_when_data_free(self):
+        cfg = {"data": {}}
+        result, has_data, data_free = resolve_training_data(
+            cfg, self.test_dir, False, {}, verbose=False
+        )
+        self.assertIsNone(result)
+        self.assertFalse(has_data)
+        self.assertTrue(data_free)
+
+    def test_disables_when_no_files_found(self):
+        empty_dir = tempfile.mkdtemp(prefix="test_empty_")
+        try:
+            cfg = {"data": {"training_file": "missing.npy"}}
+            result, has_data, data_free = resolve_training_data(
+                cfg, empty_dir, True, {"data": 1.0}, verbose=False
+            )
+            self.assertIsNone(result)
+            self.assertFalse(has_data)
+            self.assertTrue(data_free)
+        finally:
+            shutil.rmtree(empty_dir)
+
+    def test_max_time_passed_through(self):
+        cfg = {
+            "data": {
+                "source_file": "val_full_domain.npy",
+                "n_train_samples": 50,
+                "train_max_time": 0.5,  # filter to first half of data
+            },
+            "training": {"seed": 42},
+        }
+        result, _, _ = resolve_training_data(
+            cfg, self.test_dir, True, {"data": 1.0}, verbose=False
+        )
+        self.assertIsNotNone(result)
+        self.assertTrue(np.all(np.array(result[:, 0]) <= 0.5))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- New `src/data/loader.py` with `sample_training_data()` and `resolve_training_data()`:
  - Loads full domain file (`val_full_domain.npy`) into memory
  - LHS-samples `n_train_samples` points (default 2000) from config
  - Deletes source array + `gc.collect()` to free RAM
  - Falls back to pre-sampled file if source unavailable
- Replaced `load_training_data()` with `resolve_training_data()` in all experiment scripts (2-8)
- Added `data.source_file` and `data.n_train_samples` to all experiment configs
- Updated all data filenames to new naming registry

## Config keys
```yaml
data:
  source_file: val_full_domain.npy   # full spatiotemporal field
  n_train_samples: 2000              # LHS sample size at startup
  training_file: train_lhs_points.npy  # fallback if source unavailable
```

## Test plan
- [ ] `python -m unittest discover test` passes
- [ ] Run experiment 7: `python -m experiments.experiment_7.train --config configs/experiment_7.yaml` — verify it loads from source and samples 2000 points
- [ ] Verify memory freed after sampling (check print output)

Closes #161, Closes #162