### PR TITLE
feat: isolated non-dim training pipeline for experiment 1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,20 @@
 
 SWE-PINN: Physics-Informed Neural Network framework for urban flood prediction, solving 2D Shallow Water Equations with JAX/Flax. See @docs/experimental_programme_reference.md for the authoritative experiment spec.
 
+## Reporting Requirement (applies to every task)
+
+IMPORTANT: After finishing ANY task — implementation, refactor, bugfix, config change, experiment run, doc edit — always end with a **Full Implementation Report** containing:
+
+1. **Summary** — one-paragraph description of what the task accomplished.
+2. **Files changed** — every file created, modified, or deleted, with a one-line reason per file.
+3. **Key code changes** — function/class-level description of the substantive edits (not a re-print of the diff).
+4. **Configuration / hyperparameter changes** — any YAML, CLI flag, or environment variable change, with old → new values.
+5. **Commands run** — shell commands executed (training, tests, installs), their exit status, and where their outputs live.
+6. **Verification** — tests run, manual checks performed, W&B run URLs if a training job was launched, and the observed result.
+7. **Open items / follow-ups** — anything left unfinished, deferred, or that needs user review.
+
+This rule is global across all branches and overrides any default "be concise" behaviour for end-of-task summaries. Brevity is still preferred *during* the task; the full report is only at the end.
+
 ## Key Commands
 
 ```bash

--- a/configs/experiment_1/experiment_1_nondim.yaml
+++ b/configs/experiment_1/experiment_1_nondim.yaml
@@ -1,0 +1,57 @@
+training:
+  seed: 42
+  epochs: 2000
+  learning_rate: 1.0e-3
+  batch_size: 256
+  reduce_on_plateau:
+    factor: 0.5
+    patience: 10
+    rtol: 1.0e-3
+    atol: 0.0
+    cooldown: 5
+    accumulation_factor: 1
+    min_scale: 1.0e-4
+model:
+  name: MLP
+  output_dim: 3
+  width: 128
+  depth: 3
+domain:
+  lx: 1200.0
+  ly: 100.0
+  t_final: 3600.0
+physics:
+  u_const: 0.29
+  n_manning: 0.03
+  inflow: null
+  g: 9.81
+scaling:
+  enabled: true
+  H0: 1.0
+data_free: false
+train_grid:
+  n_gauges: 1
+  dt_data: 10.0
+loss_weights:
+  pde_weight: 1.0
+  ic_weight: 1.0
+  bc_weight: 1.0
+  neg_h_weight: 1.0
+  data_weight: 1.0
+plotting:
+  nx_val: 101
+  t_const_val: 1800.0
+  y_const_plot: 0
+  plot_resolution: 150
+device:
+  dtype: float32
+  early_stop_min_epochs: 4000
+  early_stop_patience: 3000
+numerics:
+  eps: 1.0e-6
+validation_grid:
+  n_points_val: 5000
+sampling:
+  n_points_pde: 8000
+  n_points_ic: 1000
+  n_points_bc_domain: 2000

--- a/configs/experiment_1/experiment_1_nondim.yaml
+++ b/configs/experiment_1/experiment_1_nondim.yaml
@@ -1,21 +1,21 @@
 training:
   seed: 42
   epochs: 2000
-  learning_rate: 1.0e-3
+  learning_rate: 1.0e-4
   batch_size: 256
   reduce_on_plateau:
     factor: 0.5
-    patience: 10
+    patience: 50
     rtol: 1.0e-3
     atol: 0.0
     cooldown: 5
-    accumulation_factor: 1
-    min_scale: 1.0e-4
+    accumulation_factor: 2
+    min_scale: 1.0e-3
 model:
   name: MLP
   output_dim: 3
-  width: 128
-  depth: 3
+  width: 512
+  depth: 4
 domain:
   lx: 1200.0
   ly: 100.0
@@ -28,16 +28,16 @@ physics:
 scaling:
   enabled: true
   H0: 1.0
-data_free: false
+data_free: true
 train_grid:
   n_gauges: 1
   dt_data: 10.0
 loss_weights:
   pde_weight: 1.0
   ic_weight: 1.0
-  bc_weight: 1.0
+  bc_weight: 10.0
   neg_h_weight: 1.0
-  data_weight: 1.0
+  data_weight: 0.0
 plotting:
   nx_val: 101
   t_const_val: 1800.0
@@ -50,8 +50,8 @@ device:
 numerics:
   eps: 1.0e-6
 validation_grid:
-  n_points_val: 5000
+  n_points_val: 20000
 sampling:
-  n_points_pde: 8000
-  n_points_ic: 1000
-  n_points_bc_domain: 2000
+  n_points_pde: 10000
+  n_points_ic: 10000
+  n_points_bc_domain: 10000

--- a/configs/experiment_1/experiment_1_nondim_cosine.yaml
+++ b/configs/experiment_1/experiment_1_nondim_cosine.yaml
@@ -1,0 +1,60 @@
+training:
+  seed: 42
+  epochs: 2000
+  learning_rate: 1.0e-4
+  batch_size: 256
+  cosine:
+    alpha: 1.0e-3          # final LR = learning_rate * alpha  (1e-4 * 1e-3 = 1e-7)
+    warmup_epochs: 0       # > 0 prepends linear warmup from 0
+  reduce_on_plateau:       # ignored by train_nondim_cosine.py; left for schema parity
+    factor: 0.5
+    patience: 50
+    rtol: 1.0e-3
+    atol: 0.0
+    cooldown: 5
+    accumulation_factor: 2
+    min_scale: 1.0e-3
+model:
+  name: MLP
+  output_dim: 3
+  width: 512
+  depth: 4
+domain:
+  lx: 1200.0
+  ly: 100.0
+  t_final: 3600.0
+physics:
+  u_const: 0.29
+  n_manning: 0.03
+  inflow: null
+  g: 9.81
+scaling:
+  enabled: true
+  H0: 1.0
+data_free: true
+train_grid:
+  n_gauges: 1
+  dt_data: 10.0
+loss_weights:
+  pde_weight: 1.0
+  ic_weight: 1.0
+  bc_weight: 10.0
+  neg_h_weight: 1.0
+  data_weight: 0.0
+plotting:
+  nx_val: 101
+  t_const_val: 1800.0
+  y_const_plot: 0
+  plot_resolution: 150
+device:
+  dtype: float32
+  early_stop_min_epochs: 4000
+  early_stop_patience: 3000
+numerics:
+  eps: 1.0e-6
+validation_grid:
+  n_points_val: 20000
+sampling:
+  n_points_pde: 10000
+  n_points_ic: 10000
+  n_points_bc_domain: 10000

--- a/configs/experiment_1/experiment_1_nondim_l2.yaml
+++ b/configs/experiment_1/experiment_1_nondim_l2.yaml
@@ -1,0 +1,57 @@
+training:
+  seed: 42
+  epochs: 5000
+  learning_rate: 1.0e-4
+  batch_size: 256
+  reduce_on_plateau:
+    factor: 0.5
+    patience: 50
+    rtol: 1.0e-3
+    atol: 0.0
+    cooldown: 5
+    accumulation_factor: 2
+    min_scale: 1.0e-3
+model:
+  name: MLP
+  output_dim: 3
+  width: 512
+  depth: 4
+domain:
+  lx: 1200.0
+  ly: 100.0
+  t_final: 3600.0
+physics:
+  u_const: 0.29
+  n_manning: 0.03
+  inflow: null
+  g: 9.81
+scaling:
+  enabled: true
+  H0: 1.0
+data_free: true
+train_grid:
+  n_gauges: 1
+  dt_data: 10.0
+loss_weights:
+  pde_weight: 1.0
+  ic_weight: 1.0
+  bc_weight: 10.0
+  neg_h_weight: 1.0
+  data_weight: 0.0
+plotting:
+  nx_val: 101
+  t_const_val: 1800.0
+  y_const_plot: 0
+  plot_resolution: 150
+device:
+  dtype: float32
+  early_stop_min_epochs: 4000
+  early_stop_patience: 3000
+numerics:
+  eps: 1.0e-6
+validation_grid:
+  n_points_val: 20000
+sampling:
+  n_points_pde: 100000
+  n_points_ic: 10000
+  n_points_bc_domain: 10000

--- a/docs/experiment_1_ablation_design.md
+++ b/docs/experiment_1_ablation_design.md
@@ -1,0 +1,293 @@
+# Experiment 1 — Ablation Study Design
+
+> **Purpose.** A controlled, discovery-driven sequence of ablations on the
+> flat-channel analytical dam-break problem (Hunter 2005, `experiment_1`)
+> that isolates and quantifies the contribution of four methodological
+> choices — input/output non-dimensionalization, loss functional (MSE vs
+> L2 norm with epsilon stabilization), collocation-point density, and
+> floating-point precision — in the order in which each was motivated by
+> the previous finding. Results form the methods baseline for all
+> subsequent experiments (2–11).
+
+---
+
+## 1. Narrative framing
+
+Rather than presenting a flat factorial of configurations, the ablation is
+structured as a **discovery story**: each step is motivated by an
+observation made in the previous step. This reflects how the methodology
+was actually developed in practice, and makes every design choice
+traceable to a diagnosed problem rather than a guessed improvement.
+
+The chain, in order:
+
+1. **Observe** a training plateau under the current best MSE configuration.
+2. **Diagnose** the plateau as gradient-flatness intrinsic to MSE as
+   losses approach zero.
+3. **Propose** replacing MSE with an L2-norm functional whose gradient
+   stays linear near the optimum.
+4. **Encounter** a new numerical issue (divergent `sqrt` gradient at
+   exactly zero) and **remedy** it with a Charbonnier-style epsilon.
+5. **Verify** the result with an orthogonal confounder check
+   (collocation-point density) to confirm L2 is the load-bearing change.
+6. **Confirm** that single precision (`float32`) is sufficient once the
+   non-dim + L2 recipe is in place.
+
+---
+
+## 2. Research questions
+
+- **RQ1.** Does non-dimensionalizing the SWE inputs **and** outputs via
+  `SWEScaler` reduce inter-term loss-scale spread and produce measurably
+  better training dynamics than input-only normalization?
+- **RQ2.** Under a non-dim MSE baseline, is the observed training plateau
+  caused by MSE's quadratic flatness near zero, or by some other factor
+  (e.g. undersampling)?
+- **RQ3.** Does replacing MSE with a per-batch L2 norm `sqrt(Σ rᵢ²)`
+  eliminate the plateau, and is the epsilon stabilizer `sqrt(Σ rᵢ² + ε)`
+  necessary for numerical stability of the gradient?
+- **RQ4.** Is the L2 + ε breakthrough load-bearing on its own, or does it
+  require the accompanying increase in collocation-point density to
+  reach the reported NSE ceiling?
+- **RQ5.** Once the non-dim + L2 + ε + dense-sampling baseline is fixed,
+  does `float64` deliver measurable accuracy benefit over `float32`, and
+  at what wall-clock cost?
+
+---
+
+## 3. Hypotheses and falsifiable predictions
+
+| ID  | Hypothesis                                                                                                                  | Falsifiable prediction |
+|-----|------------------------------------------------------------------------------------------------------------------------------|------------------------|
+| H1  | Full non-dim reduces per-term loss spread → better conditioned optimization under identical weights.                         | A1 per-term ratios closer to 1 than A0; ΔNSE ≥ 0. |
+| H2  | Under non-dim MSE, training plateaus because `∂MSE/∂θ ∝ r · ∂r/∂θ` vanishes quadratically as residual `r → 0`.                 | Per-epoch gradient-norm trace on A1 collapses by ≥ 1 decade at the plateau epoch. |
+| H3a | Replacing MSE with L2 norm preserves gradient magnitude near zero and eliminates the plateau.                                 | A3 continues improving past A1's best epoch; ΔNSE ≥ 0.10. |
+| H3b | Unmodified `sqrt(Σ r²)` has a divergent derivative at zero; ε under the sqrt is a *numerical* necessity, not a regularizer. | A2 (L2 without ε) shows gradient spikes or NaNs in late training; A3 (with ε) shows neither; final NSE unchanged to within noise. |
+| H4  | The ~0.98 NSE reached with dense sampling is a joint effect of L2 and sampling, not either alone.                              | A5 (MSE + dense sampling) < 0.75; A3 (L2 + sparse) < 0.85; A4 (L2 + dense) ≥ 0.95. |
+| H5  | For a non-dim, O(1)-residual problem, `float32` suffices.                                                                    | A6 NSE within 0.01 of A4; wall-clock ≥ 2× slower. |
+
+---
+
+## 4. Methodological framing
+
+### 4.1 Common configuration (control variables)
+
+Fixed across every ablation row:
+
+- Domain: 1200 × 100 m, `T_final = 3600 s`.
+- Architecture: MLP, width 512, depth 4.
+- Optimizer: Adam, `lr = 1e-4`, `clip_norm = 1.0`, reduce-on-plateau
+  schedule (factor 0.5, patience 50, rtol 1e-3).
+- Training: 2000 epochs, batch size 256, seed 42, early-stop disabled
+  (`min_epochs = 4000 > epochs`).
+- Loss weights: `pde=1, ic=1, bc=10, neg_h=1`; data-free.
+- Validation: 20,000-point analytical grid, NSE on water depth `h` as
+  primary selection metric.
+- Reference: analytical Hunter (2005) solution.
+
+### 4.2 Ordered ablation chain
+
+Each row **inherits** all changes from rows above, changing exactly one
+variable at a time. Variables that change are bolded.
+
+| ID | Config (target)                                       | Loss  | ε  | n_pde | dtype   | Motivation                                              |
+|----|--------------------------------------------------------|-------|-----|-------|---------|---------------------------------------------------------|
+| A0 | `experiment_1.yaml`                                    | MSE   | —   | 10k   | float32 | Current practice: input-normalized only. Baseline.      |
+| A1 | `experiment_1_nondim.yaml`                             | MSE   | —   | 10k   | float32 | **+ output non-dim** → RQ1. Expected to reveal plateau. |
+| A2 | `experiment_1_nondim_l2_noeps.yaml` *(new)*            | **L2**| **0**| 10k  | float32 | **MSE → L2, no ε** → RQ3a (does L2 help?) and RQ3b first half (does pure sqrt have numerical issues?). |
+| A3 | `experiment_1_nondim_l2.yaml`                           | L2    | **1e-12** | 10k | float32 | **+ ε stabilization** → RQ3b second half. Expected: same accuracy as A2, strictly smoother gradients. |
+| A4 | `experiment_1_nondim_l2_dense.yaml` *(new)*             | L2    | 1e-12 | **100k** | float32 | **+ dense sampling** → final headline result (~0.98 NSE reported empirically). |
+| A5 | `experiment_1_nondim_mse_dense.yaml` *(new, decoupling)* | **MSE** | — | 100k | float32 | **Confounder isolation**: MSE with dense sampling. Tests whether L2 or sampling is load-bearing (RQ4). |
+| A6 | `experiment_1_nondim_l2_f64.yaml` *(new)*               | L2    | 1e-12 | 100k  | **float64** | **+ precision** → RQ5. |
+
+Note: **A5 is a decoupling run, not an inherited step**. It branches
+from A1 (not A4) to isolate the effect of point count under MSE. Without
+A5, any claim that L2 caused the breakthrough is confounded with the
+simultaneous change in sampling density. A5 is the single most important
+run in this design.
+
+### 4.3 Replication protocol
+
+Primary reporting uses **a single seed (42)** per row. The analytical
+reference is deterministic and the measured deltas between adjacent
+rows (~0.2 NSE) are much larger than any plausible seed-to-seed noise
+on this verification problem.
+
+**Sensitivity spot-check:** one row — the headline A4 (L2 + ε + dense) —
+is additionally run with seeds 123 and 2024, to empirically bound
+seed variance. If `std(NSE) < 0.02` across the 3 seeds of A4, the
+single-seed protocol for the other rows is justified in text. If
+`std(NSE) ≥ 0.02`, the protocol is escalated to 3 seeds for all rows.
+
+Total runs: **7** (6 inherited + A5 decoupler) + **2 sensitivity seeds**
+on A4 = **9 training runs**.
+
+### 4.4 Metrics
+
+| Group       | Metric                                         | Purpose in this study |
+|-------------|-------------------------------------------------|-----------------------|
+| Primary     | NSE on `h` (global, best-of-run)               | Headline convergence quality |
+| Primary     | Epoch at which best NSE is reached              | Diagnoses plateau vs continued improvement |
+| Diagnostic  | Per-term loss trajectories (`pde`, `ic`, `bc`, `neg_h`) | Inter-term scale balance (RQ1) |
+| Diagnostic  | Global gradient norm ‖∇θ L‖ per epoch          | Gradient-flatness evidence for H2; spike detection for H3b |
+| Supporting  | NSE on `hu`, `hv`                              | Velocity field fidelity |
+| Supporting  | RMSE, MAE, Rel L2 on `h`                       | Error magnitude and localization |
+| Supporting  | Mass balance E_mass (max, final)               | Physical plausibility |
+| Cost        | Total training wall-clock (s)                  | RQ5 cost comparison |
+
+All metrics computed by the shared `evaluation/metrics/` modules specified
+in `docs/experimental_programme_reference.md`.
+
+---
+
+## 5. Expected outcome table
+
+Format for the headline results table in the write-up:
+
+| Ablation | Change                  | NSE (h) | Best epoch | ‖∇θ L‖ at plateau | Wall-clock |
+|----------|-------------------------|--------:|-----------:|------------------:|-----------:|
+| A0       | baseline (input-norm)   |    —    |      —     |         —         |    1.0×    |
+| A1       | + non-dim               |    —    |      —     |         —         |    ≈1.0×   |
+| A2       | + L2 (ε = 0)            |    —    |      —     |         —         |    ≈1.0×   |
+| A3       | + ε = 1e-12             |    —    |      —     |         —         |    ≈1.0×   |
+| A4       | + dense sampling (100k) |    —    |      —     |         —         |    ~10×    |
+| A5       | MSE + dense (decoupling)|    —    |      —     |         —         |    ~10×    |
+| A6       | + float64               |    —    |      —     |         —         |    ~25×    |
+
+Empirical observations to date (informal, pre-ablation):
+
+- A1 ≈ 0.55 (plateau at epoch ~270).
+- A3 ≈ 0.76 (at 10k points, with ε).
+- A4 ≈ 0.98 (at 100k points, with ε).
+
+These numbers must be **re-run under the protocol above** before they
+enter the manuscript. They are recorded here only to set expectation
+scale and to flag that A5 — currently missing — is the critical
+confounder check.
+
+---
+
+## 6. Write-up structure (thesis chapter)
+
+The chapter follows the discovery narrative, not the ablation row order:
+
+1. **Problem setup.** Hunter (2005) analytical dam-break, domain, BCs, IC.
+2. **Common training protocol.** §4.1, verbatim.
+3. **Observation: a training plateau.** Present A0 → A1. Show the plateau
+   at epoch ~270 despite non-dim and show per-term loss trajectories.
+   (H1 pass/fail on non-dim's benefit; H2 plateau observation.)
+4. **Diagnosis: gradient flatness of MSE.** Analytic derivation of
+   `∂MSE/∂θ` magnitude near `r ≈ 0`; empirical gradient-norm trace
+   from A1 confirming the predicted collapse. (H2 verdict.)
+5. **Remedy: L2 norm.** Derivation of `∂‖r‖₂/∂θ` showing the gradient
+   magnitude is bounded below as long as the residual vector is non-zero.
+   Present A2 (pure L2): show the plateau is broken but also show any
+   observed gradient spikes / NaNs that motivate the next step.
+   (H3a verdict; first half of H3b.)
+6. **Numerical stabilization: the ε trick.** The `sqrt` divergence at
+   zero; Charbonnier loss analogy; A3 as A2 + `ε = 1e-12`. Show gradient
+   trace is strictly smoother and final NSE is preserved. (H3b verdict.)
+7. **Confounder check: does sampling density explain the breakthrough?**
+   Present A5 (MSE + dense sampling) and A4 (L2 + dense sampling) side
+   by side. Decompose the 0.55 → 0.98 jump into an L2 component and a
+   sampling component; show neither alone reaches 0.98. (H4 verdict.)
+8. **Precision: do we need float64?** A4 vs A6. Quantify the cost/benefit.
+   (H5 verdict.)
+9. **Summary.** Which choices carry forward as defaults for Experiments
+   2–11 and why.
+
+---
+
+## 7. Deliverables
+
+### 7.1 Code artifacts (to be produced)
+
+- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_noeps.yaml`
+      (A2) — copy of `experiment_1_nondim_l2.yaml` with a new
+      `training.l2_eps: 0.0` key.
+- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_dense.yaml`
+      (A4) — copy with `sampling.n_points_pde: 100000` (and
+      `n_points_ic`, `n_points_bc_domain` matched to 100000).
+- [ ] Config `configs/experiment_1/experiment_1_nondim_mse_dense.yaml`
+      (A5) — copy of `experiment_1_nondim.yaml` (MSE path) with the
+      same dense-sampling settings as A4. **Critical decoupling run.**
+- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_f64.yaml`
+      (A6) — copy of A4 with `device.dtype: float64`.
+- [ ] Refactor `experiments/experiment_1/train_nondim_l2.py` to read
+      `training.l2_eps` from config (default 1e-12) so A2 and A3 share
+      one training script, and the A2 vs A3 comparison is literally a
+      one-line config diff.
+- [ ] Add **gradient-norm logging** (global ‖∇θ L‖ per epoch) to
+      `train_nondim_l2.py` output and/or tracker. This is the primary
+      diagnostic evidence for H2 and H3b — the ablation story does not
+      work without it. (If adding to the shared training loop is out
+      of scope, log it in the local custom loop.)
+- [ ] `scripts/ablation_exp1.sh` — runs A0–A6 + 2 sensitivity seeds
+      sequentially.
+- [ ] `scripts/aggregate_exp1_ablation.py` — collects per-run
+      `training_history.json` + best-NSE stats and emits §5 table as
+      both CSV and LaTeX.
+
+### 7.2 Figures (publication-quality, Exeter + Blue Heart palette, 300 DPI)
+
+- **F1.** Per-term loss trajectories A0 vs A1 (log y, 4 subplots).
+  Evidence for H1.
+- **F2.** Validation NSE(epoch) overlay for A1, A2, A3, A4 on one axis.
+  The headline "L2 escapes the plateau" figure.
+- **F3.** Global gradient norm ‖∇θ L‖(epoch) overlay for A1 (MSE), A2
+  (L2 no ε), A3 (L2 with ε). Evidence for H2 and H3b.
+- **F4.** Bar decomposition of the 0.55 → 0.98 gap into L2-component
+  (A3 − A1), sampling-component (A5 − A1), and joint-excess
+  (A4 − A3 − A5 + A1). Evidence for H4.
+- **F5.** Bar chart: final NSE and wall-clock for A4 vs A6. Evidence for
+  H5.
+
+### 7.3 Tables
+
+- **T1.** §5 headline results (7 rows + seed-sensitivity footnote on A4).
+- **T2.** Per-term loss ratios (pde:ic:bc) at epoch 500 for A0 vs A1.
+- **T3.** Hypothesis verdict table (H1–H5, pass/fail, evidence pointer).
+
+---
+
+## 8. Threats to validity and mitigations
+
+- **Single analytical problem.** Exp 1 is effectively 1D and friction-only.
+  Mitigation: scope claims explicitly to "verification regime"; re-test
+  the L2 + ε recipe on Exp 2 (2D obstacle) before stating it as a
+  universal default.
+- **HPO coupling.** The tuned weights (`bc_weight=10`) were found under
+  MSE. L2 may have a different optimum weight balance. Mitigation: for
+  A3 and A4, additionally report NSE under uniform `{1,1,1,1}` weights
+  as a robustness check. If L2 is insensitive to weight choice, that is
+  itself a finding.
+- **Single seed.** Larger variance could invalidate small deltas.
+  Mitigation: the A4 sensitivity spot-check (§4.3). Report the A4
+  3-seed std explicitly and state the single-seed protocol is only
+  justified if that std < 0.02.
+- **Gradient-norm interpretation.** A collapsing global gradient is
+  consistent with both "loss is near zero" (good) and "loss is stuck on
+  a plateau" (bad). Mitigation: always plot gradient norm **alongside**
+  the loss value, so the reader can distinguish "converged" from
+  "stalled" visually.
+- **Early-stop must be disabled.** Confirm `early_stop_min_epochs >
+  epochs` in every config; otherwise A3/A4's later best-epoch could be
+  clipped prematurely.
+- **`numerics.eps = 1e-6` is not the same as `training.l2_eps`.** The
+  former is a water-depth floor inside `SWEPhysics` (prevents `1/0` in
+  flux computations). The latter is the Charbonnier stabilizer inside
+  `sqrt`. Never conflate them in the write-up; they remedy different
+  failure modes.
+
+---
+
+## 9. Relationship to the broader programme
+
+This ablation is scoped deliberately narrowly: it answers *"what is the
+correct default training recipe for a PINN on SWE in a verification
+regime"* and nothing more. The deliverable is a **methods baseline**
+that Experiments 2–11 inherit without re-litigating. Choices that this
+study deliberately does **not** investigate (adaptive weighting,
+architecture selection, sampling strategy, slope terms, data-driven
+training) are explicitly deferred to Experiments 2–11 as specified in
+`docs/experimental_programme_reference.md`.

--- a/docs/l2_loss_experiment.md
+++ b/docs/l2_loss_experiment.md
@@ -1,0 +1,104 @@
+# L2-Norm Loss for Experiment 1 (non-dim)
+
+## Motivation
+
+Under standard MSE losses, Experiment 1 training plateaus around NSE ≈ 0.55
+near epoch ~270 and fails to improve — regardless of learning-rate schedule
+(reduce-on-plateau, cosine) or non-dimensionalization. Diagnosis: as each
+term approaches its optimum, MSE goes **quadratically flat**, so gradients
+vanish before the network has actually converged on the solution.
+
+Switching from MSE to the **L2 norm** of the residual (i.e. `sqrt(sum(r²))`)
+replaces the quadratic bowl with a linear one near zero. The gradient
+magnitude stays on the same order as the residual itself, so training keeps
+making progress past the point where MSE gradients die out.
+
+**Observed effect:** NSE jumped from ~0.55 (MSE) to >0.76 (L2) within the
+same epoch budget on Experiment 1 non-dim, config `experiment_1_nondim_l2.yaml`.
+
+## The equations
+
+Given a residual vector `r = (r₁, ..., r_N)`:
+
+| Quantity       | Formula                     |
+|----------------|-----------------------------|
+| L2 norm        | `‖r‖₂ = sqrt(Σ rᵢ²)`         |
+| Squared L2     | `‖r‖₂² = Σ rᵢ²`              |
+| MSE            | `(1/N) Σ rᵢ²`                |
+| RMSE           | `sqrt(MSE) = ‖r‖₂ / sqrt(N)` |
+
+Note that L2 and RMSE differ by a constant `sqrt(N)`. For Experiment 1
+(fixed batch size across terms) that constant is absorbable into the LR,
+but once batch counts differ between loss terms the distinction matters —
+L2 rewards terms that are sampled more densely, RMSE hides the sample count.
+
+## The epsilon trick
+
+`sqrt` has an infinite gradient at zero:
+
+```
+d/dx sqrt(x) = 1 / (2·sqrt(x))  →  ∞   as x → 0
+```
+
+If any loss term approaches zero (common for IC in data-free PINN runs),
+the autodiff gradient explodes and destabilizes training. Fix:
+
+```python
+_SQRT_EPS = 1e-12
+L = sqrt(sum_of_squares + _SQRT_EPS)
+```
+
+The epsilon sits inside the root, so the gradient near zero caps at
+`1 / (2·sqrt(eps)) ≈ 5e5` instead of diverging. For values `>> 1e-12` the
+output is numerically identical to `sqrt(sum_of_squares)`.
+
+This is standard practice in numerical optimization (Charbonnier loss,
+pseudo-Huber, etc.) and is cheap — one add per term per step.
+
+## Implementation pattern
+
+All shared loss helpers in `src/losses/` return **MSE**
+(i.e. `jnp.mean(residual²)`). To get true L2 norm at the call site:
+
+```python
+_SQRT_EPS = 1e-12
+
+def _l2(sum_sq):
+    return jnp.sqrt(sum_sq + _SQRT_EPS)
+
+# Recover sum from mean by multiplying by N before the sqrt:
+n_pde = pde_batch.shape[0]
+terms['pde'] = _l2(compute_pde_loss(...) * n_pde)
+```
+
+For terms assembled from multiple sub-residuals (e.g. 4-wall BC), sum the
+sums before a single sqrt — this treats the boundary as one concatenated
+residual vector and applies a single L2 norm.
+
+## When to use L2 vs MSE
+
+**Prefer L2** when:
+- Training plateaus while individual loss terms still look non-zero.
+- You suspect gradient-flatness is the bottleneck, not loss imbalance.
+- Different terms have comparable sample counts (or you want to expose
+  sample-count differences rather than hide them).
+
+**Keep MSE** when:
+- Losses are already large and training is progressing normally — MSE's
+  quadratic amplification of big errors is helpful early on.
+- You're running a weight-balancing scheme (ReLoBRaLo, SoftAdapt) that
+  assumes smooth loss ratios; L2 and MSE both work but the ratios behave
+  differently and you may need to re-tune temperature / EMA.
+
+## Files
+
+- `experiments/experiment_1/train_nondim_l2.py` — training script with the
+  `_l2` helper and true-L2 `compute_losses`.
+- `configs/experiment_1/experiment_1_nondim_l2.yaml` — matching config.
+
+## Run
+
+```bash
+WANDB_MODE=disabled python -m experiments.experiment_1.train_nondim_l2 \
+    --config configs/experiment_1/experiment_1_nondim_l2.yaml
+```

--- a/docs/pinn_loss_landscape_fixes.md
+++ b/docs/pinn_loss_landscape_fixes.md
@@ -1,0 +1,234 @@
+# PINN Loss-Landscape Fixes for Experiment 1
+
+> Context: Experiment 1 (1200×100 m flat channel, Hunter 2005, T=3600 s, data-free)
+> shows high seed-to-seed variance in NSE_h (0.55 ± lottery, single lucky run at
+> 0.77). FP64 eliminated the numerical-noise hypothesis — the problem is the
+> multi-objective loss landscape itself. The three options below attack it
+> structurally rather than by weight tuning.
+
+---
+
+## Option 1 — Causal Training (Wang, Sankaran & Perdikaris, 2022)
+
+### Problem
+The SWE PDE is time-dependent on `t ∈ [0, 3600]`. Uniform `(x,t)` sampling lets
+the optimizer minimise the residual at `t = 3600` before `t = 0` is learned —
+a violation of physical causality. The network converges to a solution that
+satisfies the PDE *everywhere at once* in a non-causal way, which is an easy
+local minimum far from the true trajectory.
+
+### Idea
+Weight each collocation residual by an exponential of the *cumulative residual
+at earlier times*. A point at time `t_i` contributes to the loss only once the
+network has driven residuals at all `t_j < t_i` close to zero.
+
+### Formulation
+Bin collocation points by time into `N_t` chunks `t_1 < t_2 < ... < t_Nt`.
+Define the mean residual within chunk `i`:
+
+```
+L_r(t_i) = mean over (x,y) in chunk i of |R_pde(x, y, t_i; θ)|²
+```
+
+Causal weight:
+
+```
+w_i = exp( −ε · Σ_{k<i} L_r(t_k) )       (stop-gradient on the sum)
+```
+
+Weighted PDE loss:
+
+```
+L_pde_causal = (1 / N_t) · Σ_i w_i · L_r(t_i)
+```
+
+`ε ≈ 100` is the Wang 2022 default for normalised PDEs; for Experiment 1 start
+with `ε ∈ {1, 10, 100}` and pick the one where `w_i` at the final time reaches
+`≈1` only in the last 20% of training.
+
+### Expected impact
+On 1D/2D time-dependent PDEs in the PINN literature this routinely converts
+NSE from 0.5 → 0.95. It directly targets the exact failure mode we see: the
+"bad" seeds plateau at epoch ~275 because they found a non-causal minimum and
+the loss gradient gives them no reason to leave.
+
+### Cost
+- One new hyperparameter `ε`
+- ~30 LOC in `src/training/losses.py`: sort collocation points by `t`, compute
+  chunked residual, apply `jax.lax.stop_gradient` to the cumulative sum,
+  multiply, mean.
+- No architectural change.
+
+### Applies to
+Experiments 1, 4, 6–9, 11 (all time-dependent PINNs). Does **not** help
+steady-state problems.
+
+---
+
+## Option 2 — Hard Initial & Boundary Condition Constraints
+
+### Problem
+Soft constraints put IC, BC, and PDE into a single weighted sum:
+
+```
+L = λ_pde · L_pde + λ_ic · L_ic + λ_bc · L_bc + λ_neg · L_neg_h
+```
+
+This is a multi-objective problem with a Pareto front. The seed determines
+*which point on the front* the optimizer converges to — that's the basin
+lottery. Worse, the IC constraint (a 1D manifold at `t=0`) has measure zero
+against the PDE points, so `λ_ic` must be large to be felt — but then it
+fights the PDE term.
+
+### Idea
+Bake IC and BC into the ansatz so they are satisfied *by construction*,
+regardless of network weights. The network then only has to minimise `L_pde`
+(and `L_neg_h`, which Option 3 also removes). Single objective, no lottery.
+
+### Formulation for Experiment 1
+
+Let `NN_h, NN_u, NN_v : (x, y, t) → ℝ` be the raw network outputs
+(post non-dim scaling).
+
+**Initial condition** (`h(x,y,0) = h_0(x,y)`, `u = u_const`, `v = 0`):
+
+```
+h_hat(x,y,t)  = h_0(x,y)         +  φ_t(t) · NN_h(x,y,t)
+hu_hat(x,y,t) = h_0(x,y) · u_0   +  φ_t(t) · NN_hu(x,y,t)
+hv_hat(x,y,t) = 0                +  φ_t(t) · NN_hv(x,y,t)
+```
+
+where `φ_t(t) = 1 − exp(−t / τ)` is a smooth gate that is exactly 0 at `t=0`
+and approaches 1 for `t ≫ τ`. Choose `τ ≈ t_final / 20 = 180 s` so the gate
+opens well within the training window.
+
+**Boundary conditions.** For the flat channel:
+- Left inflow `x = 0`: `h = h_in`, `hu = hu_in` prescribed
+- Right outflow `x = L_x`: soft (open) — leave it in the loss or use `∂h/∂x=0`
+- Top/bottom `y = 0, L_y`: slip walls `hv = 0`
+
+Inflow can be hard-enforced with a spatial gate `φ_x(x) = 1 − exp(−x/λ)`:
+
+```
+h_hat  = h_in               +  φ_t · φ_x · NN_h
+hu_hat = hu_in              +  φ_t · φ_x · NN_hu
+```
+
+Top/bottom slip `hv = 0` can be hard-enforced with
+`φ_y(y) = y · (L_y − y) / (L_y/2)²`:
+
+```
+hv_hat = 0                  +  φ_t · φ_y · NN_hv
+```
+
+After these substitutions, `L_ic ≡ 0`, `L_bc_left ≡ 0`, `L_bc_top_bottom ≡ 0`
+*by construction*. Only the outflow BC (if you choose to keep it soft) and
+`L_pde` remain in the loss.
+
+### Expected impact
+Removes IC and most BC losses → collapses the Pareto front from 4D to 1D → the
+seed lottery largely disappears. In the Raissi et al. and Lu et al. studies,
+hard constraints typically add **+0.1 to +0.2 NSE** and cut seed variance by
+3–5×. It is the single most reliable "works on my first try" intervention for
+small-domain PINNs.
+
+### Cost
+- ~50 LOC in `src/models/`: wrap the MLP output with an ansatz module that
+  applies the gates. Keep the raw MLP unchanged so you can A/B.
+- One new hyperparameter `τ` (and optionally `λ` for the spatial inflow gate).
+- The gates must be differentiable and smooth; `1 − exp(−t/τ)` is both.
+- **Gotcha:** the IC function `h_0(x,y)` must itself be smooth and
+  `jax.grad`-able. For Experiment 1 Hunter 2005 it's a simple closed form.
+
+### Applies to
+Experiments 1, 2, 4, 7, 8, 9, 10, 11 with varying complexity. For irregular
+geometries (Exp 10, 11) the spatial gates become level-set distance functions,
+which is harder but still standard.
+
+### Reference
+Lu, Pestourie, Yao, Wang, Verdugo, Johnson (2021), *Physics-informed neural
+networks with hard constraints for inverse design* — canonical reference for
+the ansatz construction.
+
+---
+
+## Option 3 — Structural Positivity via Output Parameterization
+
+### Problem
+Water depth `h` must satisfy `h ≥ 0` everywhere. A vanilla MLP output can
+(and does) go slightly negative near wet/dry regions, triggering the soft
+penalty:
+
+```
+L_neg_h = mean( relu(−h)² )
+```
+
+Evidence from the three reference runs: all had `train/neg_h ≈ 0.0156`
+persistently. Our FP64 run drove this to `1.9e-6` (still nonzero). Any nonzero
+`L_neg_h` produces a gradient that *opposes* the PDE gradient, because the
+PDE near the wet/dry boundary wants `h → 0` from above while the penalty
+wants `h` strictly positive.
+
+### Idea
+Parameterize the *raw* output through a monotone positive function so that
+`h` is non-negative by construction:
+
+```
+h(x,y,t) = softplus(NN_h_raw(x,y,t)) + eps
+```
+
+`softplus(z) = log(1 + exp(z))` is smooth, differentiable, monotone, and
+approaches `z` for large `z`, `0` for very negative `z`. Adding a small
+`eps` (e.g. `1e-6`) keeps the PDE residual well-conditioned at the wet/dry
+interface (division by `h` appears in friction / Froude terms).
+
+An alternative: `h = eps + |NN_h_raw|`. Simpler but non-smooth at `NN=0`, so
+softplus is preferred.
+
+### Momentum variables
+For `hu, hv` there is no sign constraint — keep them linear. But if you
+enforce `h` via softplus, compute velocities safely:
+
+```
+u = hu / (h + eps)
+v = hv / (h + eps)
+```
+
+### Expected impact
+- Removes the `L_neg_h` term from the loss entirely (one fewer weight to tune,
+  one fewer Pareto axis).
+- Removes gradient conflict near wet/dry interfaces — particularly important
+  for Experiments 4, 8, 10, 11 which have true wet/dry fronts.
+- Expected NSE gain alone: +0.02 to +0.05 for Experiment 1 (it's a small
+  effect on a flat channel that never really goes dry), but much larger
+  (+0.1+) for Experiments 4, 8, 11.
+
+### Cost
+- ~5 LOC in the model forward pass.
+- No new hyperparameter.
+- **Gotcha:** the IC ansatz in Option 2 assumes `NN_h` is the raw output. If
+  combining Options 2 and 3, apply softplus *before* the ansatz gating:
+  `h_hat = h_0 + φ_t · (softplus(NN_h_raw) − h_0)` — this preserves both hard
+  IC and structural positivity simultaneously.
+
+### Applies to
+Experiments 1–11 (universal).
+
+---
+
+## Combined Recommendation
+
+Implement in this order — each is independent and each provides a measurable
+step-change:
+
+1. **Option 3** first (5 LOC, universal, no new hyperparameter) — establishes
+   that `neg_h` pathology is gone in all future runs.
+2. **Option 2** second (hard IC + left/top/bottom BCs) — this alone should
+   collapse the seed lottery on Experiment 1. At this point run 5 seeds; you
+   should see mean ≳ 0.85 NSE with std < 0.05.
+3. **Option 1** last, only if (1)+(2) do not reach the target NSE, or when
+   moving to longer-horizon experiments (4, 6–9, 11) where causality becomes
+   the binding constraint.
+
+All three are additive and architecturally compatible with the existing
+`MLP`, `Fourier`, and `DGM` backbones in `src/models/`.

--- a/docs/scaling_reference.md
+++ b/docs/scaling_reference.md
@@ -1,0 +1,193 @@
+# SWE Non-Dimensionalization Reference
+
+This document describes the non-dimensionalization algorithm implemented in
+`src/physics/scaling.py` and applied in the experiment training scripts.
+
+## 1. Scale Computation (one-time at startup)
+
+```
+Inputs from config:
+  g_phys = scaling.g           (default 9.81 m/s^2)
+  H0     = scaling.H0          (default 1.0 m)
+  n      = physics.n_manning
+  Lx     = domain.lx
+  Ly     = domain.ly
+
+Computed constants (stored in SWEScaler, never updated):
+  L0  = max(Lx, Ly)
+  U0  = sqrt(g_phys * H0)          # shallow-water celerity
+  T0  = L0 / U0                    # advective timescale
+  HU0 = H0 * U0                    # output scale for hu, hv
+  Cf  = g_phys * n^2 * L0 / H0^(4/3)   # dimensionless friction number
+```
+
+**Key**: `g_phys` comes from `scaling.g`, NOT `physics.g`. The scaler
+always uses the true physical gravity regardless of what `physics.g` is
+set to in the config.
+
+## 2. Config Transformation
+
+`nondim_physics_config()` produces a config for the PDE loss:
+
+| Key | Original | Nondim |
+|-----|----------|--------|
+| `physics.g` | any | `1.0` (absorbed into scaling) |
+| `physics.n_manning` | 0.03 | `0.0` (absorbed into Cf) |
+| `physics.Cf` | absent | `10.59` (dimensionless friction) |
+| `physics.dimensional.g` | absent | `9.81` (preserved for analytical BCs) |
+| `physics.dimensional.n_manning` | absent | `0.03` (preserved) |
+| `physics.dimensional.u_const` | absent | `0.29` (preserved) |
+
+## 3. Scaling Rules
+
+Exactly two operations. Every variable passes through exactly one, never both.
+
+### SCALE (dimensional -> non-dimensional)
+
+| Variable | Formula | When |
+|----------|---------|------|
+| x, y | x* = x / L0 | Before network forward pass |
+| t | t* = t / T0 | Before network forward pass |
+| z_b | z* = z_b / H0 | Once during data prep |
+| h | h* = h / H0 | BC/IC/data targets entering loss |
+| hu | (hu)* = hu / HU0 | BC/IC/data targets entering loss |
+| hv | (hv)* = hv / HU0 | BC/IC/data targets entering loss |
+
+### UNSCALE (non-dimensional -> dimensional)
+
+| Variable | Formula | When |
+|----------|---------|------|
+| h* | h = h* * H0 | Network output -> validation/plots |
+| (hu)* | hu = (hu)* * HU0 | Network output -> validation/plots |
+| (hv)* | hv = (hv)* * HU0 | Network output -> validation/plots |
+
+## 4. Data Flow
+
+### Training
+
+```
+SAMPLING:
+  Ranges in non-dim space (computed once before JIT):
+    x_range = (0, Lx/L0),  y_range = (0, Ly/L0),  t_range = (0, t_final/T0)
+  All sample_domain() calls use scaled ranges.
+  Points are born in non-dim space.
+
+FORWARD PASS:
+  (x*, y*, t*) -> network -> (h*, (hu)*, (hv)*)
+
+PDE RESIDUAL (all in * space, g=1, Cf only):
+  Autodiff: dU*/dx*, dU*/dy*, dU*/dt*
+  Flux Jacobians with g=1.0
+  Source: Cf replaces n^2, g=1.0
+  Loss = mean(|R * h_mask|^2)
+
+BC LOSS:
+  1. Recover dimensional time: t_dim = t* * T0
+  2. Evaluate analytical solution: h_dim = h_exact(0, t_dim, n, u_const)
+  3. Scale target: h_target = h_dim / H0, hu_target = hu_dim / HU0
+  4. Compare: loss = mean((network_output - target)^2)
+```
+
+### Validation
+
+```
+  1. Forward pass: U*_pred = model(val_pts_nd)
+  2. UNSCALE: h_pred = h* * H0, hu_pred = (hu)* * HU0
+  3. Compare with DIMENSIONAL ground truth
+  4. Metrics in SI units (RMSE in metres, NSE dimensionless)
+```
+
+### Plotting
+
+```
+  1. Build points in dimensional space
+  2. Scale inputs for network
+  3. Forward pass -> U*
+  4. Unscale outputs
+  5. Plot with dimensional axes (m, m^2/s, s)
+```
+
+## 5. Non-Dimensional PDE
+
+Continuity:
+```
+R_cont = dh*/dt* + d(hu)*/dx* + d(hv)*/dy*
+```
+
+x-momentum:
+```
+R_xmom = d(hu)*/dt*
+       + d[ (hu)*^2/h* + h*^2/2 ]/dx*
+       + d[ (hu)*(hv)*/h* ]/dy*
+       + h* dz*/dx*
+       + Cf (hu)* sqrt((hu)*^2 + (hv)*^2) / h*^(7/3)
+```
+
+y-momentum:
+```
+R_ymom = d(hv)*/dt*
+       + d[ (hu)*(hv)*/h* ]/dx*
+       + d[ (hv)*^2/h* + h*^2/2 ]/dy*
+       + h* dz*/dy*
+       + Cf (hv)* sqrt((hu)*^2 + (hv)*^2) / h*^(7/3)
+```
+
+**g does not appear anywhere.** The pressure flux is `h*^2/2`, not `g*h*^2/2`.
+
+### Friction implementation note
+
+The code computes friction using primitive variables (u, v) derived from
+conservative variables:
+
+```python
+u = hu / max(h, eps)
+v = hv / max(h, eps)
+vel = sqrt(u^2 + v^2)
+sfx = Cf * u * vel / h^(4/3)
+S_xmom = -1.0 * h * sfx
+```
+
+This is mathematically equivalent to the conservative form:
+
+```
+-Cf * (hu) * sqrt((hu)^2 + (hv)^2) / h^(7/3)
+```
+
+Proof: substitute u = hu/h into `h * Cf * u * vel / h^(4/3)`:
+```
+= Cf * hu * vel / h^(4/3)
+= Cf * hu * sqrt(u^2 + v^2) / h^(4/3)
+= Cf * hu * sqrt((hu)^2 + (hv)^2) / (h * h^(4/3))
+= Cf * hu * sqrt((hu)^2 + (hv)^2) / h^(7/3)
+```
+
+## 6. Identity Mode
+
+When `scaling.enabled: false` (default):
+
+```
+L0 = H0 = U0 = T0 = HU0 = 1.0
+Cf = physics.g * n^2   (dimensional)
+nondim_physics_config returns original config unchanged
+```
+
+The pipeline runs identically to before the feature existed.
+
+## 7. File Locations
+
+| Component | File | Entry point |
+|-----------|------|-------------|
+| Scaler | `src/physics/scaling.py` | `SWEScaler` |
+| SWE source with Cf | `src/physics/swe.py` | `SWEPhysics.source(Cf=...)` |
+| PDE loss | `src/losses/pde.py` | reads `config["physics"]["Cf"]` |
+| IS residual | `src/balancing/importance_sampling.py` | same pattern |
+| Config | `configs/experiment_1/best_trial_51_config.yaml` | `scaling.*` |
+
+## 8. Config Example
+
+```yaml
+scaling:
+  enabled: true    # false = dimensional mode (identity scaler)
+  H0: 1.0          # reference depth [m]
+  # g: 9.81        # physical gravity [m/s^2] (default, rarely changed)
+```

--- a/experiments/experiment_1/train_nondim.py
+++ b/experiments/experiment_1/train_nondim.py
@@ -1,0 +1,515 @@
+"""Experiment 1 — Analytical dam-break with non-dimensionalized pipeline.
+
+Isolated non-dim variant of ``experiments.experiment_1.train``. Uses
+``SWEScaler`` to transform the SWE into a dimensionless system:
+
+- Inputs (x, y, t) sampled in non-dim ranges and fed directly to the network.
+- Model is initialised with a config whose ``domain.lx/ly/t_final`` are already
+  scaled, so the internal ``Normalize`` layer maps the non-dim domain to
+  ``[-1, 1]`` without double-scaling.
+- PDE loss reads ``physics.Cf`` from a scaled-physics FrozenDict (g=1, n=0).
+- BC Dirichlet targets are computed dimensionally via the analytical solution
+  (using original ``n_manning`` / ``u_const`` preserved under
+  ``physics.dimensional``) and scaled before entering the loss.
+- Analytical gauge data is generated dimensionally, then coordinates + targets
+  are scaled.
+- Validation sampled dimensionally, inputs scaled before the forward pass,
+  predictions unscaled to SI units before metrics.
+
+When ``scaling.enabled: false`` the scaler is an identity and the script
+reduces to the dimensional baseline.
+"""
+
+import os
+import sys
+import argparse
+import copy
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax import random
+from flax.core import FrozenDict
+
+from src.config import load_config, get_dtype
+from src.predict.predictor import _apply_min_depth
+from src.data import sample_domain
+from src.losses import (
+    compute_pde_loss, compute_ic_loss, compute_data_loss, compute_neg_h_loss,
+    loss_boundary_dirichlet, loss_boundary_neumann_outflow_x,
+    loss_boundary_wall_horizontal,
+)
+from src.utils import nse, rmse, relative_l2, plot_h_vs_x
+from src.physics import h_exact, hu_exact, hv_exact
+from src.physics.scaling import SWEScaler
+from src.training import (
+    create_optimizer,
+    calculate_num_batches,
+    extract_loss_weights,
+    get_active_loss_weights,
+    get_boundary_segment_count,
+    get_experiment_name,
+    get_sampling_count_from_config,
+    init_model_from_config,
+    train_step_jitted,
+    make_scan_body,
+    sample_and_batch,
+    maybe_batch_data,
+    post_training_save,
+    resolve_data_mode,
+    run_training_loop,
+    create_output_dirs,
+)
+
+
+def compute_losses(model, params, batch, config, data_free, scaler=None):
+    """Compute all loss terms for Experiment 1 in non-dim space.
+
+    ``config`` is expected to be the FrozenDict returned by
+    ``SWEScaler.nondim_physics_config`` so the PDE loss reads ``physics.Cf``,
+    ``physics.g=1``, ``physics.n_manning=0`` and the original dimensional
+    values are recoverable under ``physics.dimensional``. When ``scaler`` is
+    ``None`` or identity-mode, the function degrades to the dimensional path.
+    """
+    terms = {}
+
+    pde_batch_data = batch.get('pde', jnp.empty((0, 3), dtype=get_dtype()))
+    if pde_batch_data.shape[0] > 0:
+        terms['pde'] = compute_pde_loss(model, params, pde_batch_data, config)
+        terms['neg_h'] = compute_neg_h_loss(model, params, pde_batch_data)
+
+    ic_batch_data = batch.get('ic', jnp.empty((0, 3), dtype=get_dtype()))
+    if ic_batch_data.shape[0] > 0:
+        terms['ic'] = compute_ic_loss(model, params, ic_batch_data)
+
+    bc_batches = batch.get('bc', {})
+    if any(b.shape[0] > 0 for b in bc_batches.values() if hasattr(b, 'shape')):
+        left = bc_batches.get('left', jnp.empty((0, 3), dtype=get_dtype()))
+        right = bc_batches.get('right', jnp.empty((0, 3), dtype=get_dtype()))
+        bottom = bc_batches.get('bottom', jnp.empty((0, 3), dtype=get_dtype()))
+        top = bc_batches.get('top', jnp.empty((0, 3), dtype=get_dtype()))
+
+        # Pull original dimensional physics values. nondim_physics_config stores
+        # these under physics.dimensional; dimensional mode keeps them at the
+        # top level of physics.
+        physics_cfg = config["physics"]
+        dim_physics = physics_cfg.get("dimensional", physics_cfg)
+        u_dim = dim_physics.get("u_const", physics_cfg.get("u_const"))
+        n_dim = dim_physics.get("n_manning", physics_cfg.get("n_manning"))
+
+        # Recover dimensional time for the analytical solution
+        t_left_dim = left[..., 2] * scaler.T0 if scaler is not None else left[..., 2]
+        h_true_dim = h_exact(0.0, t_left_dim, n_dim, u_dim)
+        hu_true_dim = h_true_dim * u_dim
+        if scaler is not None:
+            h_target = h_true_dim / scaler.H0
+            hu_target = hu_true_dim / scaler.HU0
+        else:
+            h_target = h_true_dim
+            hu_target = hu_true_dim
+
+        loss_left = (loss_boundary_dirichlet(model, params, left, h_target, var_idx=0) +
+                     loss_boundary_dirichlet(model, params, left, hu_target, var_idx=1))
+        # Right: Neumann outflow (scale-invariant)
+        loss_right = loss_boundary_neumann_outflow_x(model, params, right)
+        # Top/Bottom: horizontal wall (scale-invariant)
+        loss_bottom = loss_boundary_wall_horizontal(model, params, bottom)
+        loss_top = loss_boundary_wall_horizontal(model, params, top)
+        terms['bc'] = loss_left + loss_right + loss_bottom + loss_top
+
+    data_batch_data = batch.get('data', jnp.empty((0, 6), dtype=get_dtype()))
+    if not data_free and data_batch_data.shape[0] > 0:
+        terms['data'] = compute_data_loss(model, params, data_batch_data, config)
+
+    return terms
+
+
+def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
+    """Set up the non-dim Experiment 1 trial.
+
+    Returns the standard training-context dict plus ``scaler`` for downstream
+    plotting / inference.
+    """
+    cfg = FrozenDict(cfg_dict)
+    experiment_name = get_experiment_name(cfg_dict, "experiment_1")
+
+    # --- Build the scaler and non-dim physics config ---
+    scaler = SWEScaler(cfg)
+    print(scaler.summary())
+    nondim_cfg = scaler.nondim_physics_config(cfg_dict)
+
+    # Build a model-init config with SCALED domain bounds so the internal
+    # Normalize layer operates on dimensionless coordinates instead of
+    # double-scaling already-scaled inputs.
+    model_init_cfg_dict = copy.deepcopy(cfg_dict)
+    model_init_cfg_dict["domain"]["lx"] = cfg_dict["domain"]["lx"] / scaler.L0
+    model_init_cfg_dict["domain"]["ly"] = cfg_dict["domain"]["ly"] / scaler.L0
+    model_init_cfg_dict["domain"]["t_final"] = cfg_dict["domain"]["t_final"] / scaler.T0
+    model_init_cfg = FrozenDict(model_init_cfg_dict)
+
+    model, params, train_key, val_key = init_model_from_config(model_init_cfg)
+
+    print("Info: Running Experiment 1 in NON-DIM analytical mode.")
+
+    static_weights_dict, _ = extract_loss_weights(cfg)
+
+    # --- Validation data: sample dimensionally, scale inputs, keep targets SI ---
+    val_points, h_true_val, hu_true_val, hv_true_val = None, None, None, None
+    validation_data_loaded = False
+    try:
+        val_grid_cfg = cfg["validation_grid"]
+        domain_cfg = cfg["domain"]
+        print("Creating analytical validation set from 'validation_grid' config...")
+
+        val_points_dim = sample_domain(
+            val_key,
+            val_grid_cfg["n_points_val"],
+            (0., domain_cfg["lx"]), (0., domain_cfg["ly"]), (0., domain_cfg["t_final"])
+        )
+        n_manning = cfg["physics"]["n_manning"]
+        u_const = cfg["physics"]["u_const"]
+        h_true_val = h_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+        hu_true_val = hu_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+        hv_true_val = hv_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+
+        # Network inputs must be non-dim; metrics stay in SI
+        val_points = scaler.scale_inputs(val_points_dim)
+
+        if val_points.shape[0] > 0:
+            validation_data_loaded = True
+            print(f"Created analytical validation set with {val_points.shape[0]} points.")
+        else:
+            print("Warning: Analytical validation set is empty.")
+    except KeyError:
+        print("Warning: 'validation_grid' not found in config. Skipping NSE/RMSE calculation.")
+    except Exception as e:
+        print(f"Warning: Error creating analytical validation set: {e}. Skipping NSE/RMSE.")
+
+    # --- Data mode resolution ---
+    data_points_full = None
+    data_free, has_data_loss = resolve_data_mode(cfg)
+
+    if not data_free:
+        try:
+            train_grid_cfg = cfg["train_grid"]
+            domain_cfg = cfg["domain"]
+            print("Creating analytical training dataset from 'train_grid' config...")
+
+            n_gauges = train_grid_cfg["n_gauges"]
+            dt_data = train_grid_cfg["dt_data"]
+            t_final = domain_cfg["t_final"]
+
+            if n_gauges <= 0 or dt_data <= 0:
+                raise ValueError(
+                    f"Gauge-based sampling requires n_gauges > 0 and dt_data > 0, "
+                    f"got n_gauges={n_gauges}, dt_data={dt_data}. "
+                    f"Set data_free: true to skip data sampling."
+                )
+
+            t_steps = jnp.arange(0., t_final + dt_data * 0.5, dt_data, dtype=get_dtype())
+            n_timesteps = t_steps.shape[0]
+
+            gauge_xy = sample_domain(
+                train_key,
+                n_gauges,
+                (0., domain_cfg["lx"]), (0., domain_cfg["ly"]), (0., 0.)
+            )[:, :2]
+
+            gauge_xy_rep = jnp.repeat(gauge_xy, n_timesteps, axis=0)
+            t_rep = jnp.tile(t_steps, n_gauges).reshape(-1, 1)
+            data_points_coords = jnp.hstack([gauge_xy_rep, t_rep])
+
+            print(f"Gauge-based sampling: {n_gauges} gauges x {n_timesteps} timesteps "
+                  f"(dt={dt_data}s) = {data_points_coords.shape[0]} data points")
+
+            # Dimensional analytical targets
+            h_true_train = h_exact(
+                data_points_coords[:, 0],
+                data_points_coords[:, 2],
+                cfg["physics"]["n_manning"],
+                cfg["physics"]["u_const"],
+            )
+            u_true_train = jnp.full_like(h_true_train, cfg["physics"]["u_const"])
+            v_true_train = jnp.zeros_like(h_true_train)
+
+            # Scale coordinates and conservative targets, then recover primitive
+            # velocities from the scaled conservative quantities so the data
+            # loss (which compares [h, u, v]) sees a self-consistent triplet.
+            coords_scaled = scaler.scale_inputs(data_points_coords)
+            h_sc, hu_sc, hv_sc = scaler.scale_outputs(
+                h_true_train,
+                h_true_train * u_true_train,
+                h_true_train * v_true_train,
+            )
+            eps_safe = 1e-12
+            u_sc = hu_sc / jnp.maximum(h_sc, eps_safe)
+            v_sc = hv_sc / jnp.maximum(h_sc, eps_safe)
+
+            data_points_full = jnp.stack([
+                coords_scaled[:, 2],  # t*
+                coords_scaled[:, 0],  # x*
+                coords_scaled[:, 1],  # y*
+                h_sc,
+                u_sc,
+                v_sc,
+            ], axis=1).astype(get_dtype())
+
+            if data_points_full.shape[0] == 0:
+                print("Warning: Analytical training data is empty. Disabling data loss.")
+                data_points_full = None
+                has_data_loss = False
+            else:
+                print(f"Created {data_points_full.shape[0]} points for data loss term "
+                      f"(weight={static_weights_dict.get('data', 0.0):.2e}).")
+        except KeyError:
+            print("Error: 'data_free: false' but 'train_grid' not found. Disabling data loss.")
+            has_data_loss = False
+            data_free = True
+        except Exception as e:
+            print(f"Error creating analytical training data: {e}. Disabling data loss.")
+            has_data_loss = False
+            data_free = True
+
+    # --- Active loss terms ---
+    current_weights_dict = get_active_loss_weights(
+        static_weights_dict,
+        data_free=data_free,
+        excluded_keys={"building_bc"},
+    )
+    active_loss_term_keys = list(current_weights_dict.keys())
+
+    # --- Batch counts ---
+    batch_size = cfg["training"]["batch_size"]
+    domain_cfg = cfg["domain"]
+
+    n_pde = get_sampling_count_from_config(cfg, "n_points_pde") if ('pde' in active_loss_term_keys or 'neg_h' in active_loss_term_keys) else 0
+    n_ic = get_sampling_count_from_config(cfg, "n_points_ic") if 'ic' in active_loss_term_keys else 0
+    n_bc_domain = get_sampling_count_from_config(cfg, "n_points_bc_domain") if 'bc' in active_loss_term_keys else 0
+    n_bc_per_wall = get_boundary_segment_count(cfg, n_bc_domain) if n_bc_domain > 0 else 0
+
+    num_batches = calculate_num_batches(
+        batch_size,
+        [n_pde, n_ic, n_bc_per_wall, n_bc_per_wall, n_bc_per_wall, n_bc_per_wall],
+        data_points_full,
+        data_free=data_free,
+    )
+
+    if num_batches == 0:
+        raise ValueError(
+            f"Batch size {batch_size} is too large for configured sample counts or data."
+        )
+
+    optimiser = create_optimizer(cfg, num_batches=num_batches)
+    opt_state = optimiser.init(params)
+
+    # --- Non-dim sampling ranges (computed once) ---
+    x_range_s = scaler.scale_range(0., domain_cfg["lx"], "x")
+    y_range_s = scaler.scale_range(0., domain_cfg["ly"], "y")
+    t_range_s = scaler.scale_range(0., domain_cfg["t_final"], "t")
+    x_left_s = scaler.scale_range(0., 0., "x")
+    x_right_s = scaler.scale_range(domain_cfg["lx"], domain_cfg["lx"], "x")
+    y_bottom_s = scaler.scale_range(0., 0., "y")
+    y_top_s = scaler.scale_range(domain_cfg["ly"], domain_cfg["ly"], "y")
+
+    def generate_epoch_data(key):
+        key, pde_key, ic_key, bc_keys, data_key = random.split(key, 5)
+
+        pde_data = sample_and_batch(pde_key, sample_domain, n_pde, batch_size, num_batches,
+                                    x_range_s, y_range_s, t_range_s)
+        ic_data = sample_and_batch(ic_key, sample_domain, n_ic, batch_size, num_batches,
+                                   x_range_s, y_range_s, (0., 0.))
+
+        l_key, r_key, b_key, t_key = random.split(bc_keys, 4)
+        bc_data = {
+            'left':   sample_and_batch(l_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_left_s, y_range_s, t_range_s),
+            'right':  sample_and_batch(r_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_right_s, y_range_s, t_range_s),
+            'bottom': sample_and_batch(b_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_range_s, y_bottom_s, t_range_s),
+            'top':    sample_and_batch(t_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_range_s, y_top_s, t_range_s),
+        }
+
+        return {
+            'pde': pde_data,
+            'ic': ic_data,
+            'bc': bc_data,
+            'data': maybe_batch_data(data_key, data_points_full, batch_size, num_batches, data_free),
+            'building_bc': {},
+        }
+
+    generate_epoch_data_jit = jax.jit(generate_epoch_data)
+
+    # Bind the scaler into compute_losses so scan_body's signature is unchanged.
+    _losses_fn = functools.partial(compute_losses, scaler=scaler)
+    scan_body = make_scan_body(
+        train_step_jitted, model, optimiser, current_weights_dict, nondim_cfg, data_free,
+        compute_losses_fn=_losses_fn,
+    )
+
+    def validation_fn(model, params):
+        nse_val, rmse_val = -jnp.inf, jnp.inf
+        metrics = {}
+        if validation_data_loaded:
+            try:
+                U_pred_nd = model.apply({'params': params['params']}, val_points, train=False)
+                U_pred_dim = scaler.unscale_output_array(U_pred_nd)
+                min_depth_val = cfg.get("numerics", {}).get("min_depth", 0.0)
+                U_pred_dim = _apply_min_depth(U_pred_dim, min_depth_val)
+                h_pred = U_pred_dim[..., 0]
+                nse_val = float(nse(h_pred, h_true_val))
+                rmse_val = float(rmse(h_pred, h_true_val))
+                metrics = {
+                    'nse_h': nse_val,
+                    'rmse_h': rmse_val,
+                    'rel_l2_h': float(relative_l2(h_pred, h_true_val)),
+                }
+                if hu_true_val is not None and hv_true_val is not None:
+                    metrics['nse_hu'] = float(nse(U_pred_dim[..., 1], hu_true_val))
+                    metrics['rmse_hu'] = float(rmse(U_pred_dim[..., 1], hu_true_val))
+                    metrics['rel_l2_hu'] = float(relative_l2(U_pred_dim[..., 1], hu_true_val))
+                    metrics['nse_hv'] = float(nse(U_pred_dim[..., 2], hv_true_val))
+                    metrics['rmse_hv'] = float(rmse(U_pred_dim[..., 2], hv_true_val))
+                    metrics['rel_l2_hv'] = float(relative_l2(U_pred_dim[..., 2], hv_true_val))
+            except Exception as exc:
+                print(f"Warning: Validation calculation failed: {exc}")
+        if not metrics:
+            metrics = {'nse_h': float(nse_val), 'rmse_h': float(rmse_val)}
+        return metrics
+
+    n_eval = 200
+
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 6)
+        batch = {
+            'pde': sample_domain(keys[0], n_eval, x_range_s, y_range_s, t_range_s),
+            'ic': sample_domain(keys[1], n_eval, x_range_s, y_range_s, (0., 0.)),
+            'bc': {
+                'left': sample_domain(keys[2], n_eval, x_left_s, y_range_s, t_range_s),
+                'right': sample_domain(keys[3], n_eval, x_right_s, y_range_s, t_range_s),
+                'bottom': sample_domain(keys[4], n_eval, x_range_s, y_bottom_s, t_range_s),
+                'top': sample_domain(keys[5], n_eval, x_range_s, y_top_s, t_range_s),
+            },
+            'data': jnp.empty((0, 6), dtype=get_dtype()),
+            'building_bc': {},
+        }
+        return compute_losses(model, params, batch, nondim_cfg, data_free=True, scaler=scaler)
+
+    return {
+        "cfg": cfg,
+        "cfg_dict": cfg_dict,
+        "model": model,
+        "params": params,
+        "train_key": train_key,
+        "optimiser": optimiser,
+        "opt_state": opt_state,
+        "generate_epoch_data_jit": generate_epoch_data_jit,
+        "scan_body": scan_body,
+        "num_batches": num_batches,
+        "validation_fn": validation_fn,
+        "data_free": data_free,
+        "compute_all_losses_fn": compute_all_losses_fn,
+        "scaler": scaler,
+        "experiment_name": experiment_name,
+        "validation_data_loaded": validation_data_loaded,
+        "val_points_all": val_points,
+        "h_true_val_all": h_true_val,
+        "val_targets_all": None,
+    }
+
+
+def main(config_path: str):
+    """Non-dim Experiment 1 training entry point."""
+    cfg_dict = load_config(config_path)
+    ctx = setup_trial(cfg_dict)
+
+    experiment_name = ctx["experiment_name"]
+    trial_name, results_dir, model_dir = create_output_dirs(ctx["cfg"], experiment_name)
+
+    model = ctx["model"]
+    cfg = ctx["cfg"]
+    scaler = ctx["scaler"]
+
+    loop_result = run_training_loop(
+        cfg=cfg,
+        cfg_dict=ctx["cfg_dict"],
+        model=model,
+        params=ctx["params"],
+        opt_state=ctx["opt_state"],
+        train_key=ctx["train_key"],
+        optimiser=ctx["optimiser"],
+        generate_epoch_data_jit=ctx["generate_epoch_data_jit"],
+        scan_body=ctx["scan_body"],
+        num_batches=ctx["num_batches"],
+        experiment_name=experiment_name,
+        trial_name=trial_name,
+        results_dir=results_dir,
+        model_dir=model_dir,
+        config_path=config_path,
+        validation_fn=ctx["validation_fn"],
+        compute_all_losses_fn=ctx["compute_all_losses_fn"],
+    )
+
+    def plot_fn(final_params):
+        print("  Generating 1D validation plot...")
+        tracker = loop_result["tracker"]
+        plot_cfg = cfg.get("plotting", {})
+        min_depth_plot = cfg.get("numerics", {}).get("min_depth", 0.0)
+        t_const_val_plot = plot_cfg.get("t_const_val", cfg["domain"]["t_final"] / 2.0)
+        nx_val_plot = plot_cfg.get("nx_val", 101)
+        y_const_plot = plot_cfg.get("y_const_plot", 0.0)
+
+        # Build the line in dimensional space, then scale for the network.
+        x_val_dim = jnp.linspace(0.0, cfg["domain"]["lx"], nx_val_plot, dtype=get_dtype())
+        plot_points_dim = jnp.stack([
+            x_val_dim,
+            jnp.full_like(x_val_dim, y_const_plot, dtype=get_dtype()),
+            jnp.full_like(x_val_dim, t_const_val_plot, dtype=get_dtype()),
+        ], axis=1)
+        plot_points_nd = scaler.scale_inputs(plot_points_dim)
+        U_plot_nd = model.apply({'params': final_params['params']}, plot_points_nd, train=False)
+        U_plot_dim = scaler.unscale_output_array(U_plot_nd)
+        U_plot_dim = _apply_min_depth(U_plot_dim, min_depth_plot)
+        h_plot_pred_1d = U_plot_dim[..., 0]
+        plot_path_1d = os.path.join(results_dir, "final_validation_plot.png")
+        plot_h_vs_x(x_val_dim, h_plot_pred_1d, t_const_val_plot, y_const_plot,
+                    ctx["cfg_dict"], plot_path_1d)
+        tracker.log_image(plot_path_1d, 'validation_plot_1D')
+        print(f"Model and plot saved in {model_dir} and {results_dir}")
+
+    post_training_save(
+        loop_result=loop_result,
+        model=model,
+        model_dir=model_dir,
+        results_dir=results_dir,
+        trial_name=trial_name,
+        plot_fn=plot_fn,
+    )
+
+    return loop_result["best_nse_stats"]["nse"] if loop_result["best_nse_stats"]["nse"] > -jnp.inf else -1.0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Non-dim PINN training for Experiment 1 (analytical).")
+    parser.add_argument("--config", type=str, required=True, help="Path to the configuration file.")
+    args = parser.parse_args()
+
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+        print(f"Added project root to path: {project_root}")
+
+    try:
+        final_nse = main(args.config)
+        print("\n--- Script Finished ---")
+        if isinstance(final_nse, (float, int)) and final_nse > -jnp.inf:
+            print(f"Final best NSE reported: {final_nse:.6f}")
+        else:
+            print(f"Final best NSE value invalid or not achieved: {final_nse}")
+        print("-----------------------")
+    except FileNotFoundError as e:
+        print(f"Error: {e}. Please check the config file path.")
+    except ValueError as e:
+        print(f"Configuration or Model Error: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        import traceback
+        traceback.print_exc()

--- a/experiments/experiment_1/train_nondim_cosine.py
+++ b/experiments/experiment_1/train_nondim_cosine.py
@@ -1,0 +1,556 @@
+"""Experiment 1 — Non-dim analytical dam-break with cosine LR schedule.
+
+Isolated variant of ``train_nondim.py``. Identical physics / scaling /
+loss pipeline, but replaces the default ``reduce_on_plateau`` optimiser
+with a locally-built cosine-decay schedule from ``learning_rate`` down
+to ``learning_rate * cosine.alpha`` over the full ``epochs * num_batches``
+steps. Optional linear warmup via ``cosine.warmup_epochs``.
+
+Config block (under ``training``) — optional; absence falls back to the
+dimensional baseline's reduce_on_plateau::
+
+    cosine:
+      alpha: 1.0e-3        # final LR = learning_rate * alpha
+      warmup_epochs: 0     # > 0 prepends linear warmup from 0
+
+The shared ``extract_lr`` helper only reads ``reduce_on_plateau`` state;
+when cosine is active the logged LR column is the cosine schedule value
+recomputed inside the loop from the global step counter.
+"""
+
+import os
+import sys
+import argparse
+import copy
+import functools
+
+import jax
+import jax.numpy as jnp
+import optax
+from jax import random
+from flax.core import FrozenDict
+
+from src.config import load_config, get_dtype
+from src.predict.predictor import _apply_min_depth
+from src.data import sample_domain
+from src.losses import (
+    compute_pde_loss, compute_ic_loss, compute_data_loss, compute_neg_h_loss,
+    loss_boundary_dirichlet, loss_boundary_neumann_outflow_x,
+    loss_boundary_wall_horizontal,
+)
+from src.utils import nse, rmse, relative_l2, plot_h_vs_x
+from src.physics import h_exact, hu_exact, hv_exact
+from src.physics.scaling import SWEScaler
+from src.training import (
+    calculate_num_batches,
+    extract_loss_weights,
+    get_active_loss_weights,
+    get_boundary_segment_count,
+    get_experiment_name,
+    get_sampling_count_from_config,
+    init_model_from_config,
+    train_step_jitted,
+    make_scan_body,
+    sample_and_batch,
+    maybe_batch_data,
+    post_training_save,
+    resolve_data_mode,
+    run_training_loop,
+    create_output_dirs,
+)
+
+
+def _build_cosine_optimizer(cfg, num_batches):
+    """Build clip → adam(cosine_schedule) without reduce_on_plateau.
+
+    Returns ``(optimiser, lr_fn)`` where ``lr_fn(step)`` yields the
+    schedule value for a given global step.
+    """
+    training_cfg = cfg.get("training", {})
+    cosine_cfg = training_cfg.get("cosine", {}) or {}
+    base_lr = float(training_cfg["learning_rate"])
+    clip_norm = float(training_cfg.get("clip_norm", 1.0))
+    epochs = int(training_cfg["epochs"])
+    decay_steps = max(int(epochs * num_batches), 1)
+    alpha = float(cosine_cfg.get("alpha", 1.0e-3))
+    warmup_epochs = int(cosine_cfg.get("warmup_epochs", 0))
+
+    if warmup_epochs > 0:
+        warmup_steps = warmup_epochs * num_batches
+        lr_fn = optax.warmup_cosine_decay_schedule(
+            init_value=0.0,
+            peak_value=base_lr,
+            warmup_steps=warmup_steps,
+            decay_steps=decay_steps,
+            end_value=base_lr * alpha,
+        )
+    else:
+        lr_fn = optax.cosine_decay_schedule(
+            init_value=base_lr,
+            decay_steps=decay_steps,
+            alpha=alpha,
+        )
+
+    optimiser = optax.chain(
+        optax.clip_by_global_norm(clip_norm),
+        optax.adam(learning_rate=lr_fn),
+    )
+    return optimiser, lr_fn
+
+
+def compute_losses(model, params, batch, config, data_free, scaler=None):
+    """Compute all loss terms for Experiment 1 in non-dim space.
+
+    ``config`` is expected to be the FrozenDict returned by
+    ``SWEScaler.nondim_physics_config`` so the PDE loss reads ``physics.Cf``,
+    ``physics.g=1``, ``physics.n_manning=0`` and the original dimensional
+    values are recoverable under ``physics.dimensional``. When ``scaler`` is
+    ``None`` or identity-mode, the function degrades to the dimensional path.
+    """
+    terms = {}
+
+    pde_batch_data = batch.get('pde', jnp.empty((0, 3), dtype=get_dtype()))
+    if pde_batch_data.shape[0] > 0:
+        terms['pde'] = compute_pde_loss(model, params, pde_batch_data, config)
+        terms['neg_h'] = compute_neg_h_loss(model, params, pde_batch_data)
+
+    ic_batch_data = batch.get('ic', jnp.empty((0, 3), dtype=get_dtype()))
+    if ic_batch_data.shape[0] > 0:
+        terms['ic'] = compute_ic_loss(model, params, ic_batch_data)
+
+    bc_batches = batch.get('bc', {})
+    if any(b.shape[0] > 0 for b in bc_batches.values() if hasattr(b, 'shape')):
+        left = bc_batches.get('left', jnp.empty((0, 3), dtype=get_dtype()))
+        right = bc_batches.get('right', jnp.empty((0, 3), dtype=get_dtype()))
+        bottom = bc_batches.get('bottom', jnp.empty((0, 3), dtype=get_dtype()))
+        top = bc_batches.get('top', jnp.empty((0, 3), dtype=get_dtype()))
+
+        # Pull original dimensional physics values. nondim_physics_config stores
+        # these under physics.dimensional; dimensional mode keeps them at the
+        # top level of physics.
+        physics_cfg = config["physics"]
+        dim_physics = physics_cfg.get("dimensional", physics_cfg)
+        u_dim = dim_physics.get("u_const", physics_cfg.get("u_const"))
+        n_dim = dim_physics.get("n_manning", physics_cfg.get("n_manning"))
+
+        # Recover dimensional time for the analytical solution
+        t_left_dim = left[..., 2] * scaler.T0 if scaler is not None else left[..., 2]
+        h_true_dim = h_exact(0.0, t_left_dim, n_dim, u_dim)
+        hu_true_dim = h_true_dim * u_dim
+        if scaler is not None:
+            h_target = h_true_dim / scaler.H0
+            hu_target = hu_true_dim / scaler.HU0
+        else:
+            h_target = h_true_dim
+            hu_target = hu_true_dim
+
+        loss_left = (loss_boundary_dirichlet(model, params, left, h_target, var_idx=0) +
+                     loss_boundary_dirichlet(model, params, left, hu_target, var_idx=1))
+        # Right: Neumann outflow (scale-invariant)
+        loss_right = loss_boundary_neumann_outflow_x(model, params, right)
+        # Top/Bottom: horizontal wall (scale-invariant)
+        loss_bottom = loss_boundary_wall_horizontal(model, params, bottom)
+        loss_top = loss_boundary_wall_horizontal(model, params, top)
+        terms['bc'] = loss_left + loss_right + loss_bottom + loss_top
+
+    data_batch_data = batch.get('data', jnp.empty((0, 6), dtype=get_dtype()))
+    if not data_free and data_batch_data.shape[0] > 0:
+        terms['data'] = compute_data_loss(model, params, data_batch_data, config)
+
+    return terms
+
+
+def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
+    """Set up the non-dim Experiment 1 trial.
+
+    Returns the standard training-context dict plus ``scaler`` for downstream
+    plotting / inference.
+    """
+    cfg = FrozenDict(cfg_dict)
+    experiment_name = get_experiment_name(cfg_dict, "experiment_1")
+
+    # --- Build the scaler and non-dim physics config ---
+    scaler = SWEScaler(cfg)
+    print(scaler.summary())
+    nondim_cfg = scaler.nondim_physics_config(cfg_dict)
+
+    # Build a model-init config with SCALED domain bounds so the internal
+    # Normalize layer operates on dimensionless coordinates instead of
+    # double-scaling already-scaled inputs.
+    model_init_cfg_dict = copy.deepcopy(cfg_dict)
+    model_init_cfg_dict["domain"]["lx"] = cfg_dict["domain"]["lx"] / scaler.L0
+    model_init_cfg_dict["domain"]["ly"] = cfg_dict["domain"]["ly"] / scaler.L0
+    model_init_cfg_dict["domain"]["t_final"] = cfg_dict["domain"]["t_final"] / scaler.T0
+    model_init_cfg = FrozenDict(model_init_cfg_dict)
+
+    model, params, train_key, val_key = init_model_from_config(model_init_cfg)
+
+    print("Info: Running Experiment 1 in NON-DIM analytical mode.")
+
+    static_weights_dict, _ = extract_loss_weights(cfg)
+
+    # --- Validation data: sample dimensionally, scale inputs, keep targets SI ---
+    val_points, h_true_val, hu_true_val, hv_true_val = None, None, None, None
+    validation_data_loaded = False
+    try:
+        val_grid_cfg = cfg["validation_grid"]
+        domain_cfg = cfg["domain"]
+        print("Creating analytical validation set from 'validation_grid' config...")
+
+        val_points_dim = sample_domain(
+            val_key,
+            val_grid_cfg["n_points_val"],
+            (0., domain_cfg["lx"]), (0., domain_cfg["ly"]), (0., domain_cfg["t_final"])
+        )
+        n_manning = cfg["physics"]["n_manning"]
+        u_const = cfg["physics"]["u_const"]
+        h_true_val = h_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+        hu_true_val = hu_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+        hv_true_val = hv_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+
+        # Network inputs must be non-dim; metrics stay in SI
+        val_points = scaler.scale_inputs(val_points_dim)
+
+        if val_points.shape[0] > 0:
+            validation_data_loaded = True
+            print(f"Created analytical validation set with {val_points.shape[0]} points.")
+        else:
+            print("Warning: Analytical validation set is empty.")
+    except KeyError:
+        print("Warning: 'validation_grid' not found in config. Skipping NSE/RMSE calculation.")
+    except Exception as e:
+        print(f"Warning: Error creating analytical validation set: {e}. Skipping NSE/RMSE.")
+
+    # --- Data mode resolution ---
+    data_points_full = None
+    data_free, has_data_loss = resolve_data_mode(cfg)
+
+    if not data_free:
+        try:
+            train_grid_cfg = cfg["train_grid"]
+            domain_cfg = cfg["domain"]
+            print("Creating analytical training dataset from 'train_grid' config...")
+
+            n_gauges = train_grid_cfg["n_gauges"]
+            dt_data = train_grid_cfg["dt_data"]
+            t_final = domain_cfg["t_final"]
+
+            if n_gauges <= 0 or dt_data <= 0:
+                raise ValueError(
+                    f"Gauge-based sampling requires n_gauges > 0 and dt_data > 0, "
+                    f"got n_gauges={n_gauges}, dt_data={dt_data}. "
+                    f"Set data_free: true to skip data sampling."
+                )
+
+            t_steps = jnp.arange(0., t_final + dt_data * 0.5, dt_data, dtype=get_dtype())
+            n_timesteps = t_steps.shape[0]
+
+            gauge_xy = sample_domain(
+                train_key,
+                n_gauges,
+                (0., domain_cfg["lx"]), (0., domain_cfg["ly"]), (0., 0.)
+            )[:, :2]
+
+            gauge_xy_rep = jnp.repeat(gauge_xy, n_timesteps, axis=0)
+            t_rep = jnp.tile(t_steps, n_gauges).reshape(-1, 1)
+            data_points_coords = jnp.hstack([gauge_xy_rep, t_rep])
+
+            print(f"Gauge-based sampling: {n_gauges} gauges x {n_timesteps} timesteps "
+                  f"(dt={dt_data}s) = {data_points_coords.shape[0]} data points")
+
+            # Dimensional analytical targets
+            h_true_train = h_exact(
+                data_points_coords[:, 0],
+                data_points_coords[:, 2],
+                cfg["physics"]["n_manning"],
+                cfg["physics"]["u_const"],
+            )
+            u_true_train = jnp.full_like(h_true_train, cfg["physics"]["u_const"])
+            v_true_train = jnp.zeros_like(h_true_train)
+
+            # Scale coordinates and conservative targets, then recover primitive
+            # velocities from the scaled conservative quantities so the data
+            # loss (which compares [h, u, v]) sees a self-consistent triplet.
+            coords_scaled = scaler.scale_inputs(data_points_coords)
+            h_sc, hu_sc, hv_sc = scaler.scale_outputs(
+                h_true_train,
+                h_true_train * u_true_train,
+                h_true_train * v_true_train,
+            )
+            eps_safe = 1e-12
+            u_sc = hu_sc / jnp.maximum(h_sc, eps_safe)
+            v_sc = hv_sc / jnp.maximum(h_sc, eps_safe)
+
+            data_points_full = jnp.stack([
+                coords_scaled[:, 2],  # t*
+                coords_scaled[:, 0],  # x*
+                coords_scaled[:, 1],  # y*
+                h_sc,
+                u_sc,
+                v_sc,
+            ], axis=1).astype(get_dtype())
+
+            if data_points_full.shape[0] == 0:
+                print("Warning: Analytical training data is empty. Disabling data loss.")
+                data_points_full = None
+                has_data_loss = False
+            else:
+                print(f"Created {data_points_full.shape[0]} points for data loss term "
+                      f"(weight={static_weights_dict.get('data', 0.0):.2e}).")
+        except KeyError:
+            print("Error: 'data_free: false' but 'train_grid' not found. Disabling data loss.")
+            has_data_loss = False
+            data_free = True
+        except Exception as e:
+            print(f"Error creating analytical training data: {e}. Disabling data loss.")
+            has_data_loss = False
+            data_free = True
+
+    # --- Active loss terms ---
+    current_weights_dict = get_active_loss_weights(
+        static_weights_dict,
+        data_free=data_free,
+        excluded_keys={"building_bc"},
+    )
+    active_loss_term_keys = list(current_weights_dict.keys())
+
+    # --- Batch counts ---
+    batch_size = cfg["training"]["batch_size"]
+    domain_cfg = cfg["domain"]
+
+    n_pde = get_sampling_count_from_config(cfg, "n_points_pde") if ('pde' in active_loss_term_keys or 'neg_h' in active_loss_term_keys) else 0
+    n_ic = get_sampling_count_from_config(cfg, "n_points_ic") if 'ic' in active_loss_term_keys else 0
+    n_bc_domain = get_sampling_count_from_config(cfg, "n_points_bc_domain") if 'bc' in active_loss_term_keys else 0
+    n_bc_per_wall = get_boundary_segment_count(cfg, n_bc_domain) if n_bc_domain > 0 else 0
+
+    num_batches = calculate_num_batches(
+        batch_size,
+        [n_pde, n_ic, n_bc_per_wall, n_bc_per_wall, n_bc_per_wall, n_bc_per_wall],
+        data_points_full,
+        data_free=data_free,
+    )
+
+    if num_batches == 0:
+        raise ValueError(
+            f"Batch size {batch_size} is too large for configured sample counts or data."
+        )
+
+    optimiser, lr_fn = _build_cosine_optimizer(cfg, num_batches)
+    opt_state = optimiser.init(params)
+    cosine_cfg = cfg.get("training", {}).get("cosine", {}) or {}
+    print(f"Cosine LR schedule: init={cfg['training']['learning_rate']:.2e}, "
+          f"alpha={cosine_cfg.get('alpha', 1.0e-3)}, "
+          f"decay_steps={int(cfg['training']['epochs']) * num_batches}, "
+          f"warmup_epochs={cosine_cfg.get('warmup_epochs', 0)}")
+
+    # --- Non-dim sampling ranges (computed once) ---
+    x_range_s = scaler.scale_range(0., domain_cfg["lx"], "x")
+    y_range_s = scaler.scale_range(0., domain_cfg["ly"], "y")
+    t_range_s = scaler.scale_range(0., domain_cfg["t_final"], "t")
+    x_left_s = scaler.scale_range(0., 0., "x")
+    x_right_s = scaler.scale_range(domain_cfg["lx"], domain_cfg["lx"], "x")
+    y_bottom_s = scaler.scale_range(0., 0., "y")
+    y_top_s = scaler.scale_range(domain_cfg["ly"], domain_cfg["ly"], "y")
+
+    def generate_epoch_data(key):
+        key, pde_key, ic_key, bc_keys, data_key = random.split(key, 5)
+
+        pde_data = sample_and_batch(pde_key, sample_domain, n_pde, batch_size, num_batches,
+                                    x_range_s, y_range_s, t_range_s)
+        ic_data = sample_and_batch(ic_key, sample_domain, n_ic, batch_size, num_batches,
+                                   x_range_s, y_range_s, (0., 0.))
+
+        l_key, r_key, b_key, t_key = random.split(bc_keys, 4)
+        bc_data = {
+            'left':   sample_and_batch(l_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_left_s, y_range_s, t_range_s),
+            'right':  sample_and_batch(r_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_right_s, y_range_s, t_range_s),
+            'bottom': sample_and_batch(b_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_range_s, y_bottom_s, t_range_s),
+            'top':    sample_and_batch(t_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_range_s, y_top_s, t_range_s),
+        }
+
+        return {
+            'pde': pde_data,
+            'ic': ic_data,
+            'bc': bc_data,
+            'data': maybe_batch_data(data_key, data_points_full, batch_size, num_batches, data_free),
+            'building_bc': {},
+        }
+
+    generate_epoch_data_jit = jax.jit(generate_epoch_data)
+
+    # Bind the scaler into compute_losses so scan_body's signature is unchanged.
+    _losses_fn = functools.partial(compute_losses, scaler=scaler)
+    scan_body = make_scan_body(
+        train_step_jitted, model, optimiser, current_weights_dict, nondim_cfg, data_free,
+        compute_losses_fn=_losses_fn,
+    )
+
+    def validation_fn(model, params):
+        nse_val, rmse_val = -jnp.inf, jnp.inf
+        metrics = {}
+        if validation_data_loaded:
+            try:
+                U_pred_nd = model.apply({'params': params['params']}, val_points, train=False)
+                U_pred_dim = scaler.unscale_output_array(U_pred_nd)
+                min_depth_val = cfg.get("numerics", {}).get("min_depth", 0.0)
+                U_pred_dim = _apply_min_depth(U_pred_dim, min_depth_val)
+                h_pred = U_pred_dim[..., 0]
+                nse_val = float(nse(h_pred, h_true_val))
+                rmse_val = float(rmse(h_pred, h_true_val))
+                metrics = {
+                    'nse_h': nse_val,
+                    'rmse_h': rmse_val,
+                    'rel_l2_h': float(relative_l2(h_pred, h_true_val)),
+                }
+                if hu_true_val is not None and hv_true_val is not None:
+                    metrics['nse_hu'] = float(nse(U_pred_dim[..., 1], hu_true_val))
+                    metrics['rmse_hu'] = float(rmse(U_pred_dim[..., 1], hu_true_val))
+                    metrics['rel_l2_hu'] = float(relative_l2(U_pred_dim[..., 1], hu_true_val))
+                    metrics['nse_hv'] = float(nse(U_pred_dim[..., 2], hv_true_val))
+                    metrics['rmse_hv'] = float(rmse(U_pred_dim[..., 2], hv_true_val))
+                    metrics['rel_l2_hv'] = float(relative_l2(U_pred_dim[..., 2], hv_true_val))
+            except Exception as exc:
+                print(f"Warning: Validation calculation failed: {exc}")
+        if not metrics:
+            metrics = {'nse_h': float(nse_val), 'rmse_h': float(rmse_val)}
+        return metrics
+
+    n_eval = 200
+
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 6)
+        batch = {
+            'pde': sample_domain(keys[0], n_eval, x_range_s, y_range_s, t_range_s),
+            'ic': sample_domain(keys[1], n_eval, x_range_s, y_range_s, (0., 0.)),
+            'bc': {
+                'left': sample_domain(keys[2], n_eval, x_left_s, y_range_s, t_range_s),
+                'right': sample_domain(keys[3], n_eval, x_right_s, y_range_s, t_range_s),
+                'bottom': sample_domain(keys[4], n_eval, x_range_s, y_bottom_s, t_range_s),
+                'top': sample_domain(keys[5], n_eval, x_range_s, y_top_s, t_range_s),
+            },
+            'data': jnp.empty((0, 6), dtype=get_dtype()),
+            'building_bc': {},
+        }
+        return compute_losses(model, params, batch, nondim_cfg, data_free=True, scaler=scaler)
+
+    return {
+        "cfg": cfg,
+        "cfg_dict": cfg_dict,
+        "model": model,
+        "params": params,
+        "train_key": train_key,
+        "optimiser": optimiser,
+        "opt_state": opt_state,
+        "generate_epoch_data_jit": generate_epoch_data_jit,
+        "scan_body": scan_body,
+        "num_batches": num_batches,
+        "validation_fn": validation_fn,
+        "data_free": data_free,
+        "compute_all_losses_fn": compute_all_losses_fn,
+        "scaler": scaler,
+        "experiment_name": experiment_name,
+        "validation_data_loaded": validation_data_loaded,
+        "val_points_all": val_points,
+        "h_true_val_all": h_true_val,
+        "val_targets_all": None,
+    }
+
+
+def main(config_path: str):
+    """Non-dim Experiment 1 training entry point."""
+    cfg_dict = load_config(config_path)
+    ctx = setup_trial(cfg_dict)
+
+    experiment_name = ctx["experiment_name"]
+    trial_name, results_dir, model_dir = create_output_dirs(ctx["cfg"], experiment_name)
+
+    model = ctx["model"]
+    cfg = ctx["cfg"]
+    scaler = ctx["scaler"]
+
+    loop_result = run_training_loop(
+        cfg=cfg,
+        cfg_dict=ctx["cfg_dict"],
+        model=model,
+        params=ctx["params"],
+        opt_state=ctx["opt_state"],
+        train_key=ctx["train_key"],
+        optimiser=ctx["optimiser"],
+        generate_epoch_data_jit=ctx["generate_epoch_data_jit"],
+        scan_body=ctx["scan_body"],
+        num_batches=ctx["num_batches"],
+        experiment_name=experiment_name,
+        trial_name=trial_name,
+        results_dir=results_dir,
+        model_dir=model_dir,
+        config_path=config_path,
+        validation_fn=ctx["validation_fn"],
+        compute_all_losses_fn=ctx["compute_all_losses_fn"],
+    )
+
+    def plot_fn(final_params):
+        print("  Generating 1D validation plot...")
+        tracker = loop_result["tracker"]
+        plot_cfg = cfg.get("plotting", {})
+        min_depth_plot = cfg.get("numerics", {}).get("min_depth", 0.0)
+        t_const_val_plot = plot_cfg.get("t_const_val", cfg["domain"]["t_final"] / 2.0)
+        nx_val_plot = plot_cfg.get("nx_val", 101)
+        y_const_plot = plot_cfg.get("y_const_plot", 0.0)
+
+        # Build the line in dimensional space, then scale for the network.
+        x_val_dim = jnp.linspace(0.0, cfg["domain"]["lx"], nx_val_plot, dtype=get_dtype())
+        plot_points_dim = jnp.stack([
+            x_val_dim,
+            jnp.full_like(x_val_dim, y_const_plot, dtype=get_dtype()),
+            jnp.full_like(x_val_dim, t_const_val_plot, dtype=get_dtype()),
+        ], axis=1)
+        plot_points_nd = scaler.scale_inputs(plot_points_dim)
+        U_plot_nd = model.apply({'params': final_params['params']}, plot_points_nd, train=False)
+        U_plot_dim = scaler.unscale_output_array(U_plot_nd)
+        U_plot_dim = _apply_min_depth(U_plot_dim, min_depth_plot)
+        h_plot_pred_1d = U_plot_dim[..., 0]
+        plot_path_1d = os.path.join(results_dir, "final_validation_plot.png")
+        plot_h_vs_x(x_val_dim, h_plot_pred_1d, t_const_val_plot, y_const_plot,
+                    ctx["cfg_dict"], plot_path_1d)
+        tracker.log_image(plot_path_1d, 'validation_plot_1D')
+        print(f"Model and plot saved in {model_dir} and {results_dir}")
+
+    post_training_save(
+        loop_result=loop_result,
+        model=model,
+        model_dir=model_dir,
+        results_dir=results_dir,
+        trial_name=trial_name,
+        plot_fn=plot_fn,
+    )
+
+    return loop_result["best_nse_stats"]["nse"] if loop_result["best_nse_stats"]["nse"] > -jnp.inf else -1.0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Non-dim PINN training for Experiment 1 (analytical).")
+    parser.add_argument("--config", type=str, required=True, help="Path to the configuration file.")
+    args = parser.parse_args()
+
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+        print(f"Added project root to path: {project_root}")
+
+    try:
+        final_nse = main(args.config)
+        print("\n--- Script Finished ---")
+        if isinstance(final_nse, (float, int)) and final_nse > -jnp.inf:
+            print(f"Final best NSE reported: {final_nse:.6f}")
+        else:
+            print(f"Final best NSE value invalid or not achieved: {final_nse}")
+        print("-----------------------")
+    except FileNotFoundError as e:
+        print(f"Error: {e}. Please check the config file path.")
+    except ValueError as e:
+        print(f"Configuration or Model Error: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        import traceback
+        traceback.print_exc()

--- a/experiments/experiment_1/train_nondim_l2.py
+++ b/experiments/experiment_1/train_nondim_l2.py
@@ -1,0 +1,544 @@
+"""Experiment 1 — Non-dim variant using L2-norm (sqrt-MSE) losses.
+
+Isolated sibling of ``train_nondim.py``: identical pipeline, except each loss
+term is wrapped with ``jnp.sqrt`` so the optimizer sees an L2 norm (RMSE)
+instead of MSE. Motivation: MSE gradients go quadratically flat near the
+optimum, while sqrt-MSE gradients decay linearly, potentially keeping training
+alive past the ~epoch-270 plateau observed with MSE + cosine/plateau LR.
+
+A tiny ``_SQRT_EPS`` is added under the root to keep the gradient finite when
+a term approaches zero. No shared infrastructure or configs are modified.
+
+``SWEScaler`` transforms the SWE into a dimensionless system:
+
+- Inputs (x, y, t) sampled in non-dim ranges and fed directly to the network.
+- Model is initialised with a config whose ``domain.lx/ly/t_final`` are already
+  scaled, so the internal ``Normalize`` layer maps the non-dim domain to
+  ``[-1, 1]`` without double-scaling.
+- PDE loss reads ``physics.Cf`` from a scaled-physics FrozenDict (g=1, n=0).
+- BC Dirichlet targets are computed dimensionally via the analytical solution
+  (using original ``n_manning`` / ``u_const`` preserved under
+  ``physics.dimensional``) and scaled before entering the loss.
+- Analytical gauge data is generated dimensionally, then coordinates + targets
+  are scaled.
+- Validation sampled dimensionally, inputs scaled before the forward pass,
+  predictions unscaled to SI units before metrics.
+
+When ``scaling.enabled: false`` the scaler is an identity and the script
+reduces to the dimensional baseline.
+"""
+
+import os
+import sys
+import argparse
+import copy
+import functools
+
+import time
+
+import jax
+import jax.numpy as jnp
+from jax import lax, random
+from flax.core import FrozenDict
+import optax
+
+from src.config import load_config, get_dtype
+from src.predict.predictor import _apply_min_depth
+from src.data import sample_domain
+from src.losses import (
+    compute_pde_loss, compute_ic_loss, compute_data_loss, compute_neg_h_loss,
+    loss_boundary_dirichlet, loss_boundary_neumann_outflow_x,
+    loss_boundary_wall_horizontal,
+)
+from src.utils import nse, rmse, relative_l2, plot_h_vs_x
+from src.physics import h_exact, hu_exact, hv_exact
+from src.physics.scaling import SWEScaler
+from src.training import (
+    create_optimizer,
+    calculate_num_batches,
+    extract_loss_weights,
+    get_active_loss_weights,
+    get_boundary_segment_count,
+    get_experiment_name,
+    get_sampling_count_from_config,
+    init_model_from_config,
+    train_step_jitted,
+    make_scan_body,
+    sample_and_batch,
+    maybe_batch_data,
+    post_training_save,
+    resolve_data_mode,
+    run_training_loop,
+    create_output_dirs,
+)
+
+
+_SQRT_EPS = 1e-12
+
+
+def _l2(sum_sq):
+    """True L2 norm: ``sqrt(sum(r^2) + eps)``.
+
+    Callers must pass the **sum of squared residuals**, not the mean. Because
+    the shared loss helpers all return ``mean(r^2)``, the call sites multiply
+    by the batch count ``N`` to recover ``sum = mean * N`` before applying
+    this function. The tiny epsilon keeps the gradient ``1/(2*sqrt(x))``
+    finite near zero — see ``docs/l2_loss_experiment.md``.
+    """
+    return jnp.sqrt(sum_sq + _SQRT_EPS)
+
+
+def compute_losses(model, params, batch, config, data_free, scaler=None):
+    """Compute all loss terms for Experiment 1 as true L2 norms.
+
+    Each helper returns an MSE; we recover the sum-of-squares by multiplying
+    by the batch count ``N`` at the call site, then take ``sqrt(sum + eps)``.
+    The BC bundle is assembled as ``sqrt((sum of 4 wall sums) + eps)``, i.e.
+    one L2 norm over the concatenated boundary residual vector.
+    """
+    terms = {}
+
+    pde_batch_data = batch.get('pde', jnp.empty((0, 3), dtype=get_dtype()))
+    if pde_batch_data.shape[0] > 0:
+        n_pde = pde_batch_data.shape[0]
+        terms['pde'] = _l2(compute_pde_loss(model, params, pde_batch_data, config) * n_pde)
+        terms['neg_h'] = _l2(compute_neg_h_loss(model, params, pde_batch_data) * n_pde)
+
+    ic_batch_data = batch.get('ic', jnp.empty((0, 3), dtype=get_dtype()))
+    if ic_batch_data.shape[0] > 0:
+        n_ic = ic_batch_data.shape[0]
+        terms['ic'] = _l2(compute_ic_loss(model, params, ic_batch_data) * n_ic)
+
+    bc_batches = batch.get('bc', {})
+    if any(b.shape[0] > 0 for b in bc_batches.values() if hasattr(b, 'shape')):
+        left = bc_batches.get('left', jnp.empty((0, 3), dtype=get_dtype()))
+        right = bc_batches.get('right', jnp.empty((0, 3), dtype=get_dtype()))
+        bottom = bc_batches.get('bottom', jnp.empty((0, 3), dtype=get_dtype()))
+        top = bc_batches.get('top', jnp.empty((0, 3), dtype=get_dtype()))
+
+        # Pull original dimensional physics values. nondim_physics_config stores
+        # these under physics.dimensional; dimensional mode keeps them at the
+        # top level of physics.
+        physics_cfg = config["physics"]
+        dim_physics = physics_cfg.get("dimensional", physics_cfg)
+        u_dim = dim_physics.get("u_const", physics_cfg.get("u_const"))
+        n_dim = dim_physics.get("n_manning", physics_cfg.get("n_manning"))
+
+        # Recover dimensional time for the analytical solution
+        t_left_dim = left[..., 2] * scaler.T0 if scaler is not None else left[..., 2]
+        h_true_dim = h_exact(0.0, t_left_dim, n_dim, u_dim)
+        hu_true_dim = h_true_dim * u_dim
+        if scaler is not None:
+            h_target = h_true_dim / scaler.H0
+            hu_target = hu_true_dim / scaler.HU0
+        else:
+            h_target = h_true_dim
+            hu_target = hu_true_dim
+
+        loss_left = (loss_boundary_dirichlet(model, params, left, h_target, var_idx=0) +
+                     loss_boundary_dirichlet(model, params, left, hu_target, var_idx=1))
+        # Right: Neumann outflow (scale-invariant)
+        loss_right = loss_boundary_neumann_outflow_x(model, params, right)
+        # Top/Bottom: horizontal wall (scale-invariant)
+        loss_bottom = loss_boundary_wall_horizontal(model, params, bottom)
+        loss_top = loss_boundary_wall_horizontal(model, params, top)
+        n_wall = left.shape[0]
+        terms['bc'] = _l2((loss_left + loss_right + loss_bottom + loss_top) * n_wall)
+
+    data_batch_data = batch.get('data', jnp.empty((0, 6), dtype=get_dtype()))
+    if not data_free and data_batch_data.shape[0] > 0:
+        n_data = data_batch_data.shape[0]
+        terms['data'] = _l2(compute_data_loss(model, params, data_batch_data, config) * n_data)
+
+    return terms
+
+
+def setup_trial(cfg_dict: dict, hpo_mode: bool = False) -> dict:
+    """Set up the non-dim Experiment 1 trial.
+
+    Returns the standard training-context dict plus ``scaler`` for downstream
+    plotting / inference.
+    """
+    cfg = FrozenDict(cfg_dict)
+    experiment_name = get_experiment_name(cfg_dict, "experiment_1")
+
+    # --- Build the scaler and non-dim physics config ---
+    scaler = SWEScaler(cfg)
+    print(scaler.summary())
+    nondim_cfg = scaler.nondim_physics_config(cfg_dict)
+
+    # Build a model-init config with SCALED domain bounds so the internal
+    # Normalize layer operates on dimensionless coordinates instead of
+    # double-scaling already-scaled inputs.
+    model_init_cfg_dict = copy.deepcopy(cfg_dict)
+    model_init_cfg_dict["domain"]["lx"] = cfg_dict["domain"]["lx"] / scaler.L0
+    model_init_cfg_dict["domain"]["ly"] = cfg_dict["domain"]["ly"] / scaler.L0
+    model_init_cfg_dict["domain"]["t_final"] = cfg_dict["domain"]["t_final"] / scaler.T0
+    model_init_cfg = FrozenDict(model_init_cfg_dict)
+
+    model, params, train_key, val_key = init_model_from_config(model_init_cfg)
+
+    print("Info: Running Experiment 1 in NON-DIM analytical mode.")
+
+    static_weights_dict, _ = extract_loss_weights(cfg)
+
+    # --- Validation data: sample dimensionally, scale inputs, keep targets SI ---
+    val_points, h_true_val, hu_true_val, hv_true_val = None, None, None, None
+    validation_data_loaded = False
+    try:
+        val_grid_cfg = cfg["validation_grid"]
+        domain_cfg = cfg["domain"]
+        print("Creating analytical validation set from 'validation_grid' config...")
+
+        val_points_dim = sample_domain(
+            val_key,
+            val_grid_cfg["n_points_val"],
+            (0., domain_cfg["lx"]), (0., domain_cfg["ly"]), (0., domain_cfg["t_final"])
+        )
+        n_manning = cfg["physics"]["n_manning"]
+        u_const = cfg["physics"]["u_const"]
+        h_true_val = h_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+        hu_true_val = hu_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+        hv_true_val = hv_exact(val_points_dim[:, 0], val_points_dim[:, 2], n_manning, u_const)
+
+        # Network inputs must be non-dim; metrics stay in SI
+        val_points = scaler.scale_inputs(val_points_dim)
+
+        if val_points.shape[0] > 0:
+            validation_data_loaded = True
+            print(f"Created analytical validation set with {val_points.shape[0]} points.")
+        else:
+            print("Warning: Analytical validation set is empty.")
+    except KeyError:
+        print("Warning: 'validation_grid' not found in config. Skipping NSE/RMSE calculation.")
+    except Exception as e:
+        print(f"Warning: Error creating analytical validation set: {e}. Skipping NSE/RMSE.")
+
+    # --- Data mode resolution ---
+    data_points_full = None
+    data_free, has_data_loss = resolve_data_mode(cfg)
+
+    if not data_free:
+        try:
+            train_grid_cfg = cfg["train_grid"]
+            domain_cfg = cfg["domain"]
+            print("Creating analytical training dataset from 'train_grid' config...")
+
+            n_gauges = train_grid_cfg["n_gauges"]
+            dt_data = train_grid_cfg["dt_data"]
+            t_final = domain_cfg["t_final"]
+
+            if n_gauges <= 0 or dt_data <= 0:
+                raise ValueError(
+                    f"Gauge-based sampling requires n_gauges > 0 and dt_data > 0, "
+                    f"got n_gauges={n_gauges}, dt_data={dt_data}. "
+                    f"Set data_free: true to skip data sampling."
+                )
+
+            t_steps = jnp.arange(0., t_final + dt_data * 0.5, dt_data, dtype=get_dtype())
+            n_timesteps = t_steps.shape[0]
+
+            gauge_xy = sample_domain(
+                train_key,
+                n_gauges,
+                (0., domain_cfg["lx"]), (0., domain_cfg["ly"]), (0., 0.)
+            )[:, :2]
+
+            gauge_xy_rep = jnp.repeat(gauge_xy, n_timesteps, axis=0)
+            t_rep = jnp.tile(t_steps, n_gauges).reshape(-1, 1)
+            data_points_coords = jnp.hstack([gauge_xy_rep, t_rep])
+
+            print(f"Gauge-based sampling: {n_gauges} gauges x {n_timesteps} timesteps "
+                  f"(dt={dt_data}s) = {data_points_coords.shape[0]} data points")
+
+            # Dimensional analytical targets
+            h_true_train = h_exact(
+                data_points_coords[:, 0],
+                data_points_coords[:, 2],
+                cfg["physics"]["n_manning"],
+                cfg["physics"]["u_const"],
+            )
+            u_true_train = jnp.full_like(h_true_train, cfg["physics"]["u_const"])
+            v_true_train = jnp.zeros_like(h_true_train)
+
+            # Scale coordinates and conservative targets, then recover primitive
+            # velocities from the scaled conservative quantities so the data
+            # loss (which compares [h, u, v]) sees a self-consistent triplet.
+            coords_scaled = scaler.scale_inputs(data_points_coords)
+            h_sc, hu_sc, hv_sc = scaler.scale_outputs(
+                h_true_train,
+                h_true_train * u_true_train,
+                h_true_train * v_true_train,
+            )
+            eps_safe = 1e-12
+            u_sc = hu_sc / jnp.maximum(h_sc, eps_safe)
+            v_sc = hv_sc / jnp.maximum(h_sc, eps_safe)
+
+            data_points_full = jnp.stack([
+                coords_scaled[:, 2],  # t*
+                coords_scaled[:, 0],  # x*
+                coords_scaled[:, 1],  # y*
+                h_sc,
+                u_sc,
+                v_sc,
+            ], axis=1).astype(get_dtype())
+
+            if data_points_full.shape[0] == 0:
+                print("Warning: Analytical training data is empty. Disabling data loss.")
+                data_points_full = None
+                has_data_loss = False
+            else:
+                print(f"Created {data_points_full.shape[0]} points for data loss term "
+                      f"(weight={static_weights_dict.get('data', 0.0):.2e}).")
+        except KeyError:
+            print("Error: 'data_free: false' but 'train_grid' not found. Disabling data loss.")
+            has_data_loss = False
+            data_free = True
+        except Exception as e:
+            print(f"Error creating analytical training data: {e}. Disabling data loss.")
+            has_data_loss = False
+            data_free = True
+
+    # --- Active loss terms ---
+    current_weights_dict = get_active_loss_weights(
+        static_weights_dict,
+        data_free=data_free,
+        excluded_keys={"building_bc"},
+    )
+    active_loss_term_keys = list(current_weights_dict.keys())
+
+    # --- Batch counts ---
+    batch_size = cfg["training"]["batch_size"]
+    domain_cfg = cfg["domain"]
+
+    n_pde = get_sampling_count_from_config(cfg, "n_points_pde") if ('pde' in active_loss_term_keys or 'neg_h' in active_loss_term_keys) else 0
+    n_ic = get_sampling_count_from_config(cfg, "n_points_ic") if 'ic' in active_loss_term_keys else 0
+    n_bc_domain = get_sampling_count_from_config(cfg, "n_points_bc_domain") if 'bc' in active_loss_term_keys else 0
+    n_bc_per_wall = get_boundary_segment_count(cfg, n_bc_domain) if n_bc_domain > 0 else 0
+
+    num_batches = calculate_num_batches(
+        batch_size,
+        [n_pde, n_ic, n_bc_per_wall, n_bc_per_wall, n_bc_per_wall, n_bc_per_wall],
+        data_points_full,
+        data_free=data_free,
+    )
+
+    if num_batches == 0:
+        raise ValueError(
+            f"Batch size {batch_size} is too large for configured sample counts or data."
+        )
+
+    optimiser = create_optimizer(cfg, num_batches=num_batches)
+    opt_state = optimiser.init(params)
+
+    # --- Non-dim sampling ranges (computed once) ---
+    x_range_s = scaler.scale_range(0., domain_cfg["lx"], "x")
+    y_range_s = scaler.scale_range(0., domain_cfg["ly"], "y")
+    t_range_s = scaler.scale_range(0., domain_cfg["t_final"], "t")
+    x_left_s = scaler.scale_range(0., 0., "x")
+    x_right_s = scaler.scale_range(domain_cfg["lx"], domain_cfg["lx"], "x")
+    y_bottom_s = scaler.scale_range(0., 0., "y")
+    y_top_s = scaler.scale_range(domain_cfg["ly"], domain_cfg["ly"], "y")
+
+    def generate_epoch_data(key):
+        key, pde_key, ic_key, bc_keys, data_key = random.split(key, 5)
+
+        pde_data = sample_and_batch(pde_key, sample_domain, n_pde, batch_size, num_batches,
+                                    x_range_s, y_range_s, t_range_s)
+        ic_data = sample_and_batch(ic_key, sample_domain, n_ic, batch_size, num_batches,
+                                   x_range_s, y_range_s, (0., 0.))
+
+        l_key, r_key, b_key, t_key = random.split(bc_keys, 4)
+        bc_data = {
+            'left':   sample_and_batch(l_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_left_s, y_range_s, t_range_s),
+            'right':  sample_and_batch(r_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_right_s, y_range_s, t_range_s),
+            'bottom': sample_and_batch(b_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_range_s, y_bottom_s, t_range_s),
+            'top':    sample_and_batch(t_key, sample_domain, n_bc_per_wall, batch_size, num_batches, x_range_s, y_top_s, t_range_s),
+        }
+
+        return {
+            'pde': pde_data,
+            'ic': ic_data,
+            'bc': bc_data,
+            'data': maybe_batch_data(data_key, data_points_full, batch_size, num_batches, data_free),
+            'building_bc': {},
+        }
+
+    generate_epoch_data_jit = jax.jit(generate_epoch_data)
+
+    # Bind the scaler into compute_losses so scan_body's signature is unchanged.
+    _losses_fn = functools.partial(compute_losses, scaler=scaler)
+    scan_body = make_scan_body(
+        train_step_jitted, model, optimiser, current_weights_dict, nondim_cfg, data_free,
+        compute_losses_fn=_losses_fn,
+    )
+
+    def validation_fn(model, params):
+        nse_val, rmse_val = -jnp.inf, jnp.inf
+        metrics = {}
+        if validation_data_loaded:
+            try:
+                U_pred_nd = model.apply({'params': params['params']}, val_points, train=False)
+                U_pred_dim = scaler.unscale_output_array(U_pred_nd)
+                min_depth_val = cfg.get("numerics", {}).get("min_depth", 0.0)
+                U_pred_dim = _apply_min_depth(U_pred_dim, min_depth_val)
+                h_pred = U_pred_dim[..., 0]
+                nse_val = float(nse(h_pred, h_true_val))
+                rmse_val = float(rmse(h_pred, h_true_val))
+                metrics = {
+                    'nse_h': nse_val,
+                    'rmse_h': rmse_val,
+                    'rel_l2_h': float(relative_l2(h_pred, h_true_val)),
+                }
+                if hu_true_val is not None and hv_true_val is not None:
+                    metrics['nse_hu'] = float(nse(U_pred_dim[..., 1], hu_true_val))
+                    metrics['rmse_hu'] = float(rmse(U_pred_dim[..., 1], hu_true_val))
+                    metrics['rel_l2_hu'] = float(relative_l2(U_pred_dim[..., 1], hu_true_val))
+                    metrics['nse_hv'] = float(nse(U_pred_dim[..., 2], hv_true_val))
+                    metrics['rmse_hv'] = float(rmse(U_pred_dim[..., 2], hv_true_val))
+                    metrics['rel_l2_hv'] = float(relative_l2(U_pred_dim[..., 2], hv_true_val))
+            except Exception as exc:
+                print(f"Warning: Validation calculation failed: {exc}")
+        if not metrics:
+            metrics = {'nse_h': float(nse_val), 'rmse_h': float(rmse_val)}
+        return metrics
+
+    n_eval = 200
+
+    def compute_all_losses_fn(model, params):
+        eval_key = random.PRNGKey(0)
+        keys = random.split(eval_key, 6)
+        batch = {
+            'pde': sample_domain(keys[0], n_eval, x_range_s, y_range_s, t_range_s),
+            'ic': sample_domain(keys[1], n_eval, x_range_s, y_range_s, (0., 0.)),
+            'bc': {
+                'left': sample_domain(keys[2], n_eval, x_left_s, y_range_s, t_range_s),
+                'right': sample_domain(keys[3], n_eval, x_right_s, y_range_s, t_range_s),
+                'bottom': sample_domain(keys[4], n_eval, x_range_s, y_bottom_s, t_range_s),
+                'top': sample_domain(keys[5], n_eval, x_range_s, y_top_s, t_range_s),
+            },
+            'data': jnp.empty((0, 6), dtype=get_dtype()),
+            'building_bc': {},
+        }
+        return compute_losses(model, params, batch, nondim_cfg, data_free=True, scaler=scaler)
+
+    return {
+        "cfg": cfg,
+        "cfg_dict": cfg_dict,
+        "model": model,
+        "params": params,
+        "train_key": train_key,
+        "optimiser": optimiser,
+        "opt_state": opt_state,
+        "generate_epoch_data_jit": generate_epoch_data_jit,
+        "scan_body": scan_body,
+        "num_batches": num_batches,
+        "validation_fn": validation_fn,
+        "data_free": data_free,
+        "compute_all_losses_fn": compute_all_losses_fn,
+        "scaler": scaler,
+        "experiment_name": experiment_name,
+        "validation_data_loaded": validation_data_loaded,
+        "val_points_all": val_points,
+        "h_true_val_all": h_true_val,
+        "val_targets_all": None,
+    }
+
+
+def main(config_path: str):
+    """Non-dim Experiment 1 training entry point."""
+    cfg_dict = load_config(config_path)
+    ctx = setup_trial(cfg_dict)
+
+    experiment_name = ctx["experiment_name"]
+    trial_name, results_dir, model_dir = create_output_dirs(ctx["cfg"], experiment_name)
+
+    model = ctx["model"]
+    cfg = ctx["cfg"]
+    scaler = ctx["scaler"]
+
+    loop_result = run_training_loop(
+        cfg=cfg,
+        cfg_dict=ctx["cfg_dict"],
+        model=model,
+        params=ctx["params"],
+        opt_state=ctx["opt_state"],
+        train_key=ctx["train_key"],
+        optimiser=ctx["optimiser"],
+        generate_epoch_data_jit=ctx["generate_epoch_data_jit"],
+        scan_body=ctx["scan_body"],
+        num_batches=ctx["num_batches"],
+        experiment_name=experiment_name,
+        trial_name=trial_name,
+        results_dir=results_dir,
+        model_dir=model_dir,
+        config_path=config_path,
+        validation_fn=ctx["validation_fn"],
+        compute_all_losses_fn=ctx["compute_all_losses_fn"],
+    )
+
+    def plot_fn(final_params):
+        print("  Generating 1D validation plot...")
+        tracker = loop_result["tracker"]
+        plot_cfg = cfg.get("plotting", {})
+        min_depth_plot = cfg.get("numerics", {}).get("min_depth", 0.0)
+        t_const_val_plot = plot_cfg.get("t_const_val", cfg["domain"]["t_final"] / 2.0)
+        nx_val_plot = plot_cfg.get("nx_val", 101)
+        y_const_plot = plot_cfg.get("y_const_plot", 0.0)
+
+        # Build the line in dimensional space, then scale for the network.
+        x_val_dim = jnp.linspace(0.0, cfg["domain"]["lx"], nx_val_plot, dtype=get_dtype())
+        plot_points_dim = jnp.stack([
+            x_val_dim,
+            jnp.full_like(x_val_dim, y_const_plot, dtype=get_dtype()),
+            jnp.full_like(x_val_dim, t_const_val_plot, dtype=get_dtype()),
+        ], axis=1)
+        plot_points_nd = scaler.scale_inputs(plot_points_dim)
+        U_plot_nd = model.apply({'params': final_params['params']}, plot_points_nd, train=False)
+        U_plot_dim = scaler.unscale_output_array(U_plot_nd)
+        U_plot_dim = _apply_min_depth(U_plot_dim, min_depth_plot)
+        h_plot_pred_1d = U_plot_dim[..., 0]
+        plot_path_1d = os.path.join(results_dir, "final_validation_plot.png")
+        plot_h_vs_x(x_val_dim, h_plot_pred_1d, t_const_val_plot, y_const_plot,
+                    ctx["cfg_dict"], plot_path_1d)
+        tracker.log_image(plot_path_1d, 'validation_plot_1D')
+        print(f"Model and plot saved in {model_dir} and {results_dir}")
+
+    post_training_save(
+        loop_result=loop_result,
+        model=model,
+        model_dir=model_dir,
+        results_dir=results_dir,
+        trial_name=trial_name,
+        plot_fn=plot_fn,
+    )
+
+    return loop_result["best_nse_stats"]["nse"] if loop_result["best_nse_stats"]["nse"] > -jnp.inf else -1.0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Non-dim PINN training for Experiment 1 (analytical).")
+    parser.add_argument("--config", type=str, required=True, help="Path to the configuration file.")
+    args = parser.parse_args()
+
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
+        print(f"Added project root to path: {project_root}")
+
+    try:
+        final_nse = main(args.config)
+        print("\n--- Script Finished ---")
+        if isinstance(final_nse, (float, int)) and final_nse > -jnp.inf:
+            print(f"Final best NSE reported: {final_nse:.6f}")
+        else:
+            print(f"Final best NSE value invalid or not achieved: {final_nse}")
+        print("-----------------------")
+    except FileNotFoundError as e:
+        print(f"Error: {e}. Please check the config file path.")
+    except ValueError as e:
+        print(f"Configuration or Model Error: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        import traceback
+        traceback.print_exc()

--- a/src/losses/pde.py
+++ b/src/losses/pde.py
@@ -46,8 +46,9 @@ def compute_pde_loss(model: nn.Module, params: Dict[str, Any], pde_batch: jnp.nd
     div_G = jnp.einsum('nij,nj->ni', JG, dU_dy)
 
     # 3. Pass gradients to source term
+    Cf = config.get("physics", {}).get("Cf", None)
     S = physics.source(g=g, n_manning=n_manning, inflow=inflow,
-                       bed_grad_x=bed_grad_x, bed_grad_y=bed_grad_y)
+                       bed_grad_x=bed_grad_x, bed_grad_y=bed_grad_y, Cf=Cf)
 
     residual = (dU_dt + div_F + div_G - S)
 

--- a/src/physics/scaling.py
+++ b/src/physics/scaling.py
@@ -1,0 +1,190 @@
+"""Non-dimensionalization of the 2D Shallow Water Equations.
+
+Transforms the conservative-form SWE into a dimensionless system where all
+residual terms are O(1), eliminating gravity from the flux terms entirely.
+
+Characteristic scales (when enabled)
+-------------------------------------
+L0 : Length scale — max(Lx, Ly) from domain geometry.
+H0 : Depth scale — reference depth (configurable, default 1.0 m).
+U0 : Velocity scale — shallow-water celerity sqrt(g * H0).
+T0 : Time scale — advective timescale L0 / U0.
+
+The single dimensionless group is the friction number:
+    C_f = g * n_manning^2 * L0 / H0^(4/3)
+
+When disabled (``scaling.enabled: false``), all scales are 1.0 and
+C_f = g * n_manning^2, preserving the original dimensional pipeline.
+"""
+
+import jax.numpy as jnp
+from flax.core import FrozenDict
+
+
+class SWEScaler:
+    """Handles non-dimensionalization of inputs, outputs, and physics parameters.
+
+    Parameters
+    ----------
+    cfg : FrozenDict or dict
+        Config with keys ``domain.lx``, ``domain.ly``, ``domain.t_final``,
+        ``physics.g``, ``physics.n_manning``, and optionally ``scaling.*``.
+
+    When ``scaling.enabled`` is ``false`` (or absent), the scaler acts as an
+    identity: L0 = H0 = U0 = T0 = 1, Cf = g * n^2, and ``nondim_physics_config``
+    returns the original config unchanged.
+    """
+
+    def __init__(self, cfg):
+        domain = cfg["domain"]
+        physics = cfg["physics"]
+        scaling_cfg = cfg.get("scaling", {})
+
+        self.enabled = bool(scaling_cfg.get("enabled", False))
+        n_manning = float(physics["n_manning"])
+
+        # Physical gravity: always 9.81 m/s² unless overridden in scaling config.
+        # This is distinct from physics.g which the user may have set to 1.0
+        # for legacy dimensional runs.  The scaler needs the true physical
+        # constant to compute correct scales.
+        self.g_physical = float(scaling_cfg.get("g", 9.81))
+
+        if self.enabled:
+            self.L0 = float(max(domain["lx"], domain["ly"]))
+            self.H0 = float(scaling_cfg.get("H0", 1.0))
+            self.U0 = float(jnp.sqrt(self.g_physical * self.H0))
+            self.T0 = self.L0 / self.U0
+            self.Cf = self.g_physical * n_manning ** 2 * self.L0 / self.H0 ** (4.0 / 3.0)
+        else:
+            g_cfg = float(physics["g"])
+            self.L0 = 1.0
+            self.H0 = 1.0
+            self.U0 = 1.0
+            self.T0 = 1.0
+            self.Cf = g_cfg * n_manning ** 2
+
+        # Pre-compute output scale product for hu/hv
+        self.HU0 = self.H0 * self.U0
+
+    # ------------------------------------------------------------------
+    # Input scaling
+    # ------------------------------------------------------------------
+
+    def scale_inputs(self, pts: jnp.ndarray) -> jnp.ndarray:
+        """Scale (x, y, t) coordinates to dimensionless form.
+
+        Parameters
+        ----------
+        pts : jnp.ndarray, shape (..., 3)
+            Dimensional coordinates [x, y, t].
+
+        Returns
+        -------
+        jnp.ndarray, shape (..., 3)
+            Dimensionless coordinates [x*, y*, t*].
+        """
+        scales = jnp.array([self.L0, self.L0, self.T0], dtype=pts.dtype)
+        return pts / scales
+
+    def scale_range(self, lo: float, hi: float, dim: str) -> tuple[float, float]:
+        """Scale a dimensional range to dimensionless form.
+
+        Parameters
+        ----------
+        lo, hi : float
+            Dimensional range bounds.
+        dim : str
+            One of ``'x'``, ``'y'``, ``'t'``.
+        """
+        s = self.T0 if dim == "t" else self.L0
+        return lo / s, hi / s
+
+    # ------------------------------------------------------------------
+    # Output scaling
+    # ------------------------------------------------------------------
+
+    def scale_outputs(self, h: jnp.ndarray, hu: jnp.ndarray, hv: jnp.ndarray):
+        """Scale dimensional [h, hu, hv] to dimensionless form."""
+        return h / self.H0, hu / self.HU0, hv / self.HU0
+
+    def scale_output_array(self, U: jnp.ndarray) -> jnp.ndarray:
+        """Scale a stacked output array [..., 3] (h, hu, hv) to dimensionless form."""
+        scales = jnp.array([self.H0, self.HU0, self.HU0], dtype=U.dtype)
+        return U / scales
+
+    def unscale_outputs(self, h_star: jnp.ndarray, hu_star: jnp.ndarray, hv_star: jnp.ndarray):
+        """Convert dimensionless predictions back to dimensional form."""
+        return h_star * self.H0, hu_star * self.HU0, hv_star * self.HU0
+
+    def unscale_output_array(self, U_star: jnp.ndarray) -> jnp.ndarray:
+        """Unscale a stacked output array [..., 3] back to dimensional form."""
+        scales = jnp.array([self.H0, self.HU0, self.HU0], dtype=U_star.dtype)
+        return U_star * scales
+
+    # ------------------------------------------------------------------
+    # Bed / bathymetry scaling
+    # ------------------------------------------------------------------
+
+    def scale_bed(self, z_b: jnp.ndarray) -> jnp.ndarray:
+        """Scale bed elevation to dimensionless form."""
+        return z_b / self.H0
+
+    def scale_bed_gradient(self, dz_dx: jnp.ndarray, dz_dy: jnp.ndarray):
+        """Scale bed gradients: dz*/dx* = (L0/H0) * dz/dx."""
+        ratio = self.L0 / self.H0
+        return dz_dx * ratio, dz_dy * ratio
+
+    # ------------------------------------------------------------------
+    # Physics parameter
+    # ------------------------------------------------------------------
+
+    @property
+    def dimensionless_friction(self) -> float:
+        """Return the dimensionless friction number C_f."""
+        return self.Cf
+
+    # ------------------------------------------------------------------
+    # Config for the non-dimensional PDE
+    # ------------------------------------------------------------------
+
+    def nondim_physics_config(self, base_config) -> FrozenDict:
+        """Build a config for the non-dimensional PDE.
+
+        When scaling is **enabled**, the returned config sets ``g = 1.0``
+        (absorbed into scaling), ``n_manning = 0.0`` (friction absorbed
+        into ``Cf``), and adds ``Cf``.  The original dimensional values
+        are preserved under ``physics.dimensional``.
+
+        When scaling is **disabled**, returns the original config as a
+        FrozenDict with no modifications.
+        """
+        cfg_dict = dict(base_config)
+        if not self.enabled:
+            return FrozenDict(cfg_dict)
+
+        physics = dict(cfg_dict.get("physics", {}))
+        # Preserve original dimensional values for analytical BC computations
+        physics["dimensional"] = {
+            "n_manning": physics["n_manning"],
+            "u_const": physics.get("u_const"),
+            "g": self.g_physical,
+        }
+        physics["g"] = 1.0
+        physics["n_manning"] = 0.0
+        physics["Cf"] = self.Cf
+        cfg_dict["physics"] = physics
+        return FrozenDict(cfg_dict)
+
+    def summary(self) -> str:
+        """Return a human-readable summary of the scaling parameters."""
+        if not self.enabled:
+            return "SWE Scaling: DISABLED (dimensional mode)"
+        return (
+            f"SWE Non-dimensionalization:\n"
+            f"  g  = {self.g_physical:.2f} m/s² (physical)\n"
+            f"  L0 = {self.L0:.2f} m\n"
+            f"  H0 = {self.H0:.4f} m\n"
+            f"  U0 = {self.U0:.4f} m/s (celerity)\n"
+            f"  T0 = {self.T0:.4f} s\n"
+            f"  Cf = {self.Cf:.6f} (dimensionless friction)"
+        )

--- a/src/physics/swe.py
+++ b/src/physics/swe.py
@@ -31,11 +31,26 @@ class SWEPhysics:
         return F, G
 
     def source(self, g: float, n_manning: float, inflow: float,
-               bed_grad_x: jnp.ndarray = None, bed_grad_y: jnp.ndarray = None) -> jnp.ndarray:
-        """Compute source terms for SWE."""
+               bed_grad_x: jnp.ndarray = None, bed_grad_y: jnp.ndarray = None,
+               Cf: float = None) -> jnp.ndarray:
+        """Compute source terms for SWE.
+
+        Parameters
+        ----------
+        Cf : float, optional
+            Dimensionless friction number.  When provided, friction is
+            computed as ``Cf * u * vel / h^(4/3)`` and ``g`` is assumed
+            to be 1.0 (absorbed into scaling).  When ``None``, the
+            standard dimensional form ``n^2 * u * vel / h^(4/3)`` is
+            used with explicit ``g``.
+        """
         vel = jnp.sqrt(self.u**2 + self.v**2)
-        sfx = n_manning**2 * self.u * vel / (self.h_safe**(4 / 3))
-        sfy = n_manning**2 * self.v * vel / (self.h_safe**(4 / 3))
+        if Cf is not None:
+            sfx = Cf * self.u * vel / (self.h_safe**(4 / 3))
+            sfy = Cf * self.v * vel / (self.h_safe**(4 / 3))
+        else:
+            sfx = n_manning**2 * self.u * vel / (self.h_safe**(4 / 3))
+            sfy = n_manning**2 * self.v * vel / (self.h_safe**(4 / 3))
         sox = -bed_grad_x if bed_grad_x is not None else 0.0
         soy = -bed_grad_y if bed_grad_y is not None else 0.0
 

--- a/test/test_experiment_1_nondim.py
+++ b/test/test_experiment_1_nondim.py
@@ -1,0 +1,193 @@
+"""Smoke test for experiments.experiment_1.train_nondim.
+
+Runs a 200-epoch CPU training on a tiny MLP with non-dim scaling enabled,
+and a separate run with scaling disabled (identity mode), to verify that the
+isolated non-dim pipeline produces finite, non-collapsed metrics.
+"""
+import os
+os.environ["JAX_PLATFORM_NAME"] = "cpu"
+
+import math
+import shutil
+import sys
+import unittest
+from unittest.mock import patch
+
+import yaml
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from experiments.experiment_1.train_nondim import main as train_main
+
+
+def _base_config(scaling_enabled: bool, data_free: bool = True) -> dict:
+    return {
+        'training': {
+            'learning_rate': 1.0e-3,
+            'epochs': 200,
+            'batch_size': 32,
+            'seed': 42,
+            'clip_norm': 1.0,
+        },
+        'model': {
+            'name': 'MLP',
+            'width': 32,
+            'depth': 2,
+            'output_dim': 3,
+            'kernel_init': 'glorot_uniform',
+            'bias_init': 0.0,
+        },
+        'domain': {
+            'lx': 1200.0,
+            'ly': 100.0,
+            't_final': 3600.0,
+        },
+        'physics': {
+            'u_const': 0.29,
+            'n_manning': 0.03,
+            'inflow': None,
+            'g': 9.81,
+        },
+        'scaling': {
+            'enabled': scaling_enabled,
+            'H0': 1.0,
+        },
+        'data_free': data_free,
+        'train_grid': {
+            'n_gauges': 1,
+            'dt_data': 300.0,
+        },
+        'loss_weights': {
+            'pde_weight': 1.0,
+            'bc_weight': 1.0,
+            'ic_weight': 1.0,
+            'neg_h_weight': 1.0,
+            'data_weight': 1.0,
+        },
+        'sampling': {
+            'n_points_pde': 200,
+            'n_points_ic': 50,
+            'n_points_bc_domain': 100,
+        },
+        'validation_grid': {
+            'n_points_val': 100,
+        },
+        'wandb': {
+            'enable': False,
+        },
+        'plotting': {
+            'nx_val': 20,
+            't_const_val': 1800.0,
+            'y_const_plot': 0,
+        },
+        'device': {
+            'dtype': 'float32',
+            'early_stop_min_epochs': 500,
+            'early_stop_patience': 500,
+        },
+        'numerics': {
+            'eps': 1.0e-6,
+        },
+    }
+
+
+class TestExperiment1Nondim(unittest.TestCase):
+
+    def setUp(self):
+        self.test_dir = "test_temp"
+        os.makedirs(self.test_dir, exist_ok=True)
+        self._created_trials = []
+
+    def tearDown(self):
+        if os.path.exists(self.test_dir):
+            shutil.rmtree(self.test_dir)
+        for dir_name in ("results", "models"):
+            for trial in self._created_trials:
+                trial_path = os.path.join(dir_name, "experiment_1", trial)
+                if os.path.isdir(trial_path):
+                    shutil.rmtree(trial_path)
+
+    def _snapshot_trials(self) -> set:
+        exp_models_dir = os.path.join("models", "experiment_1")
+        if not os.path.isdir(exp_models_dir):
+            return set()
+        return set(os.listdir(exp_models_dir))
+
+    def _write_config(self, name: str, scaling_enabled: bool,
+                      data_free: bool = True) -> str:
+        path = os.path.join(self.test_dir, f"{name}.yaml")
+        with open(path, 'w') as f:
+            yaml.dump(_base_config(scaling_enabled, data_free=data_free), f)
+        return path
+
+    def _assert_final_checkpoint_exists(self, before: set) -> None:
+        exp_models_dir = os.path.join("models", "experiment_1")
+        self.assertTrue(os.path.isdir(exp_models_dir),
+                        f"Missing {exp_models_dir}")
+        after = set(os.listdir(exp_models_dir))
+        new_trials = sorted(after - before)
+        self.assertTrue(new_trials,
+                        f"No new trial dir created under {exp_models_dir}")
+        trial = new_trials[-1]
+        self._created_trials.append(trial)
+        final_ckpt = os.path.join(exp_models_dir, trial, "checkpoints", "final", "model.pkl")
+        self.assertTrue(os.path.exists(final_ckpt),
+                        f"Missing final checkpoint: {final_ckpt}")
+
+    @patch('src.training.loop.ask_for_confirmation', return_value=True)
+    def test_nondim_train_runs(self, _mock_confirm):
+        """200-epoch smoke test with scaling.enabled=true."""
+        cfg_path = self._write_config("test_config_nondim", scaling_enabled=True)
+        before = self._snapshot_trials()
+        try:
+            final_nse = train_main(cfg_path)
+        except Exception as exc:
+            self.fail(f"Non-dim training raised: {exc}")
+
+        self.assertIsNotNone(final_nse)
+        self.assertTrue(math.isfinite(float(final_nse)),
+                        f"Final NSE is not finite: {final_nse}")
+        # A1 double-scaling bug would collapse the network and drive NSE to very
+        # large negative values. -10 is a loose sanity check that training did
+        # not explode into a constant output.
+        self.assertGreater(float(final_nse), -10.0,
+                           f"NSE too low — likely input-collapse regression: {final_nse}")
+        self._assert_final_checkpoint_exists(before)
+
+    @patch('src.training.loop.ask_for_confirmation', return_value=True)
+    def test_nondim_with_gauge_data(self, _mock_confirm):
+        """Exercise the scaled gauge-data path (data_free=false)."""
+        cfg_path = self._write_config(
+            "test_config_nondim_data", scaling_enabled=True, data_free=False
+        )
+        before = self._snapshot_trials()
+        try:
+            final_nse = train_main(cfg_path)
+        except Exception as exc:
+            self.fail(f"Non-dim gauge-data training raised: {exc}")
+
+        self.assertIsNotNone(final_nse)
+        self.assertTrue(math.isfinite(float(final_nse)),
+                        f"Final NSE is not finite: {final_nse}")
+        self.assertGreater(float(final_nse), -10.0,
+                           f"NSE too low with gauge data: {final_nse}")
+        self._assert_final_checkpoint_exists(before)
+
+    @patch('src.training.loop.ask_for_confirmation', return_value=True)
+    def test_nondim_disabled_matches_dim_mode(self, _mock_confirm):
+        """200-epoch run with scaling.enabled=false proves identity-mode fallback."""
+        cfg_path = self._write_config("test_config_nondim_off", scaling_enabled=False)
+        before = self._snapshot_trials()
+        try:
+            final_nse = train_main(cfg_path)
+        except Exception as exc:
+            self.fail(f"Identity-mode non-dim training raised: {exc}")
+
+        self.assertIsNotNone(final_nse)
+        self.assertTrue(math.isfinite(float(final_nse)),
+                        f"Final NSE is not finite in identity mode: {final_nse}")
+        self._assert_final_checkpoint_exists(before)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `experiments/experiment_1/train_nondim.py` — a clean-room non-dimensionalized training pipeline for Experiment 1 (flat 1200x100m analytical dam-break), isolated from `train.py` so other experiments are unaffected.
- Cherry-picks the scaling foundation from the abandoned `feat/swe-nondimensionalization` branch: `src/physics/scaling.py` (`SWEScaler`), `docs/scaling_reference.md`, plus small backwards-compatible `Cf` additions to `src/physics/swe.py` and `src/losses/pde.py`.
- Adds `configs/experiment_1/experiment_1_nondim.yaml` (full run) and `test/test_experiment_1_nondim.py` (3-case 200-epoch CPU smoke test).

## Why a new file instead of continuing the old branch
The prior attempt had five scale-mixing bugs that prevented Experiment 1 from training at all (network inputs collapsed to near-constant). This PR fixes each explicitly:

1. **Model double-scaled inputs.** `init_model_from_config` now receives a config whose `domain.lx/ly/t_final` are pre-scaled by `L0/T0`, so the internal `Normalize` layer maps already-scaled coordinates to [-1, 1] once instead of twice.
2. **BC Dirichlet targets were in the wrong space.** Left-BC recovers `t_dim = t* * T0`, evaluates `h_exact` with the preserved dimensional `n_manning`/`u_const`, then divides by `H0`/`HU0` before feeding the loss.
3. **Gauge data was unscaled.** Analytical gauge samples are built dimensionally, then coordinates and conservative outputs are scaled, and primitive velocities recovered from `u* = hu*/h*` to match the data-loss column contract.
4. **Validation mixed spaces.** Validation samples dimensionally, scales inputs for the forward pass, unscales outputs back to SI units, and computes NSE/RMSE/Rel-L2 against dimensional ground truth per the experimental-programme spec.
5. **PDE loss saw dimensional physics.** The scan body and loss eval receive `scaler.nondim_physics_config(cfg)` — a FrozenDict with `g=1`, `n_manning=0`, `physics.Cf`, and dimensional values preserved under `physics.dimensional`.

## Smoke test results
```
Ran 3 tests in 8.0s
OK
```
- `test_nondim_train_runs`: 200 epochs, `scaling.enabled=true`, data-free → NSE finite at -0.28 (training works; 200 epochs is too few to actually solve dam-break).
- `test_nondim_with_gauge_data`: 200 epochs, `scaling.enabled=true`, `data_free=false`, 1 gauge × 300s — exercises the scaled gauge-data path end to end.
- `test_nondim_disabled_matches_dim_mode`: 200 epochs, `scaling.enabled=false` — proves identity-mode fallback runs through the non-dim script without mixing spaces.
- 32 pre-existing tests in `test_losses`, `test_physics`, `test_train` still pass (Cf additions are backwards compatible: passing `Cf=None` preserves the old path).

## Known follow-ups (intentionally out of scope)
- The companion full-size config uses neutral `loss_weights: 1.0`; Trial-51 weights were tuned for dimensional loss magnitudes and will need re-HPO in non-dim space.
- Non-dim is not wired into experiments 2–11 yet. Several latent bugs (bathymetry coords, bed-gradient rescaling, mass inflow, `eps` thresholds, `src/data/loader.py` dimensional output, `src/inference/runner.py` not scale-aware) will bite when scaling is turned on for those experiments. Documented but not fixed here — this PR keeps the blast radius on Experiment 1 only.

## Test plan
- [x] `python -m unittest test.test_experiment_1_nondim` — 3 tests pass in 8s on CPU
- [x] `python -m unittest test.test_losses test.test_physics test.test_train` — 32 regression tests still pass
- [ ] Full training run with `configs/experiment_1/experiment_1_nondim.yaml` on GPU (manual, post-merge)
- [ ] Scale-aware inference path to verify the checkpoint (separate follow-up)