### PR TITLE
feat(exp1): ablation infrastructure for A0-A6 with grad-norm logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,3 +74,35 @@ IMPORTANT: Always consult `docs/experimental_programme_reference.md` when:
 Key conventions:
 - Accuracy metrics (NSE, RMSE, MAE, Rel L2) reported separately for h, hu, hv
 - Colour palette: Exeter (Deep Green #003C3C, Teal #007D69, Mint #00C896) + Blue Heart (Navy #0D2B45, Ocean #1B5E8A, Sky #4FA3D1). Arial font. 300 DPI.
+
+---
+
+## Git Workflow
+
+- **Feature branches target `main` directly.** PR base is `main` (not a claude-cleanup branch — that rule was relaxed 2026-04-20).
+- **Squash-merge** via `gh pr merge <N> --squash --delete-branch`.
+- **Branch naming**: `feat/<area>-<short>` for features, `refactor/<short>` for refactors, `fix/<short>` for bugfixes.
+- One PR per coherent scope. If a PR grows past ~500 lines across unrelated concerns, split it.
+- Never force-push `main`.
+- Tag headline result commits (`git tag exp1-ablation-v1`) so any thesis figure can be reproduced from `git checkout <tag>`.
+
+## Repo Organization (what goes where)
+
+| Dir | Purpose |
+|---|---|
+| `src/` | Reusable library code (physics, losses, training loop, scaling, monitoring). No experiment-specific logic. |
+| `experiments/experiment_N/` | Experiment drivers. Entry-points that import from `src/` and produce a trained model. |
+| `configs/experiment_N/` | YAML hyperparameter files. One per run variant. No Python. |
+| `scripts/` | Automation around experiments — orchestrators, run launchers, aggregators, figure generators. Not experiments themselves. |
+| `test/` | Unit tests for `src/` and smoke tests for experiments. |
+| `docs/` | Design docs, session notes, workflow recipes. |
+| `models/`, `results/`, `wandb/` | Generated artifacts (gitignored). Produced by training runs. |
+
+**Rule of thumb**: if it produces a model → `experiments/`. If it consumes models/results to produce something else → `scripts/`. If it's reusable pure logic → `src/`.
+
+## Artifact Organization (models/, archive/)
+
+- **Active runs** land under `models/<timestamped-trial>/` as before (unchanged behaviour).
+- **Archived runs** live under `models/archive/` and are intentionally excluded from the rotation / hygiene sweeps. Move a run there when it produced a headline figure or thesis result you must keep.
+- **Local `wandb/` and `results/` are disposable.** W&B server is the authoritative log; local dirs can be deleted after `wandb sync`.
+- **Reproducibility**: every headline run is recoverable from (a) the git tag/SHA at the time of training, (b) the W&B run URL, (c) the saved config snapshot in `models/<trial>/`. If any of the three is missing, the run is not thesis-quality.

--- a/configs/experiment_1/experiment_1_A0.yaml
+++ b/configs/experiment_1/experiment_1_A0.yaml
@@ -1,9 +1,13 @@
+# Ablation A0 — baseline: input-normalized only, MSE loss, no output non-dim.
+# Differs from experiment_1_nondim.yaml (A1) by exactly ONE variable:
+# scaling.enabled: false. Every other hyperparameter matches §4.1 of
+# docs/experiment_1_ablation_design.md so the A0 → A1 comparison isolates
+# the effect of non-dimensionalization alone.
 training:
   seed: 42
-  epochs: 5000
+  epochs: 2000
   learning_rate: 1.0e-4
   batch_size: 256
-  l2_eps: 1.0e-12
   reduce_on_plateau:
     factor: 0.5
     patience: 50
@@ -27,7 +31,7 @@ physics:
   inflow: null
   g: 9.81
 scaling:
-  enabled: true
+  enabled: false
   H0: 1.0
 data_free: true
 train_grid:

--- a/configs/experiment_1/experiment_1_nondim_l2_dense.yaml
+++ b/configs/experiment_1/experiment_1_nondim_l2_dense.yaml
@@ -1,3 +1,6 @@
+# Ablation A4 — L2 loss + epsilon + dense (100k) collocation sampling.
+# Copy of experiment_1_nondim_l2.yaml with n_points_pde bumped to 100000.
+# Headline row: expected ~0.98 NSE empirically. H4 joint effect (L2 × density).
 training:
   seed: 42
   epochs: 5000
@@ -53,6 +56,6 @@ numerics:
 validation_grid:
   n_points_val: 20000
 sampling:
-  n_points_pde: 10000
+  n_points_pde: 100000
   n_points_ic: 10000
   n_points_bc_domain: 10000

--- a/configs/experiment_1/experiment_1_nondim_l2_f64.yaml
+++ b/configs/experiment_1/experiment_1_nondim_l2_f64.yaml
@@ -1,3 +1,7 @@
+# Ablation A6 — L2 + epsilon + dense sampling + float64.
+# Copy of experiment_1_nondim_l2_dense.yaml (A4) with device.dtype: float64.
+# Tests H5: once the non-dim + L2 + dense recipe is in place, is double
+# precision worth the ~2× wall-clock cost?
 training:
   seed: 42
   epochs: 5000
@@ -45,7 +49,7 @@ plotting:
   y_const_plot: 0
   plot_resolution: 150
 device:
-  dtype: float32
+  dtype: float64
   early_stop_min_epochs: 4000
   early_stop_patience: 3000
 numerics:
@@ -53,6 +57,6 @@ numerics:
 validation_grid:
   n_points_val: 20000
 sampling:
-  n_points_pde: 10000
+  n_points_pde: 100000
   n_points_ic: 10000
   n_points_bc_domain: 10000

--- a/configs/experiment_1/experiment_1_nondim_l2_noeps.yaml
+++ b/configs/experiment_1/experiment_1_nondim_l2_noeps.yaml
@@ -1,9 +1,13 @@
+# Ablation A2 — L2 loss without the Charbonnier epsilon stabilizer.
+# Copy of experiment_1_nondim_l2.yaml with training.l2_eps: 0.0.
+# Tests whether the ε term is numerically load-bearing (H3b first half) —
+# expect gradient spikes / NaNs late in training when a term approaches zero.
 training:
   seed: 42
   epochs: 5000
   learning_rate: 1.0e-4
   batch_size: 256
-  l2_eps: 1.0e-12
+  l2_eps: 0.0
   reduce_on_plateau:
     factor: 0.5
     patience: 50

--- a/configs/experiment_1/experiment_1_nondim_mse_dense.yaml
+++ b/configs/experiment_1/experiment_1_nondim_mse_dense.yaml
@@ -1,9 +1,12 @@
+# Ablation A5 — MSE loss + dense (100k) collocation sampling.
+# Decoupling run: isolates whether L2 or sampling density is the load-bearing
+# change behind the A1→A4 jump. Branches from A1 (not A4). Critical H4 evidence.
+# Same as experiment_1_nondim.yaml with n_points_pde: 100000 and epochs: 5000.
 training:
   seed: 42
   epochs: 5000
   learning_rate: 1.0e-4
   batch_size: 256
-  l2_eps: 1.0e-12
   reduce_on_plateau:
     factor: 0.5
     patience: 50
@@ -53,6 +56,6 @@ numerics:
 validation_grid:
   n_points_val: 20000
 sampling:
-  n_points_pde: 10000
+  n_points_pde: 100000
   n_points_ic: 10000
   n_points_bc_domain: 10000

--- a/docs/experiment_1_ablation_design.md
+++ b/docs/experiment_1_ablation_design.md
@@ -92,7 +92,7 @@ variable at a time. Variables that change are bolded.
 
 | ID | Config (target)                                       | Loss  | ε  | n_pde | dtype   | Motivation                                              |
 |----|--------------------------------------------------------|-------|-----|-------|---------|---------------------------------------------------------|
-| A0 | `experiment_1.yaml`                                    | MSE   | —   | 10k   | float32 | Current practice: input-normalized only. Baseline.      |
+| A0 | `experiment_1_A0.yaml` *(new)*                         | MSE   | —   | 10k   | float32 | Baseline: input-normalized only (`scaling.enabled: false`). Differs from A1 by exactly one variable. |
 | A1 | `experiment_1_nondim.yaml`                             | MSE   | —   | 10k   | float32 | **+ output non-dim** → RQ1. Expected to reveal plateau. |
 | A2 | `experiment_1_nondim_l2_noeps.yaml` *(new)*            | **L2**| **0**| 10k  | float32 | **MSE → L2, no ε** → RQ3a (does L2 help?) and RQ3b first half (does pure sqrt have numerical issues?). |
 | A3 | `experiment_1_nondim_l2.yaml`                           | L2    | **1e-12** | 10k | float32 | **+ ε stabilization** → RQ3b second half. Expected: same accuracy as A2, strictly smoother gradients. |
@@ -106,21 +106,19 @@ A5, any claim that L2 caused the breakthrough is confounded with the
 simultaneous change in sampling density. A5 is the single most important
 run in this design.
 
+**Cosine LR is excluded from the ablation scope.** A standalone cosine-decay variant (`train_nondim_cosine.py`) was trialled on the non-dim MSE baseline and reached the same ~0.55 NSE plateau as the reduce-on-plateau schedule, confirming that the bottleneck is not LR scheduling. LR schedule is therefore an *assumption selection*, fixed at reduce-on-plateau with the parameters in §4.1, and not a variable in this chain.
+
 ### 4.3 Replication protocol
 
-Primary reporting uses **a single seed (42)** per row. The analytical
-reference is deterministic and the measured deltas between adjacent
-rows (~0.2 NSE) are much larger than any plausible seed-to-seed noise
-on this verification problem.
+**Replication protocol (revised).** The seed is treated as a nuisance variable to pin down once, not a source of variance to characterise per-row.
 
-**Sensitivity spot-check:** one row — the headline A4 (L2 + ε + dense) —
-is additionally run with seeds 123 and 2024, to empirically bound
-seed variance. If `std(NSE) < 0.02` across the 3 seeds of A4, the
-single-seed protocol for the other rows is justified in text. If
-`std(NSE) ≥ 0.02`, the protocol is escalated to 3 seeds for all rows.
+**Seed test on A0 (prerequisite).** Before the ablation chain starts, row A0 is run with 3 seeds: 42, 123, 2024. The **median-NSE seed** is adopted as the canonical seed for all subsequent rows (A1–A6). The best and worst seeds are disclosed as a footnote.
 
-Total runs: **7** (6 inherited + A5 decoupler) + **2 sensitivity seeds**
-on A4 = **9 training runs**.
+Rationale for picking the median rather than the best: picking the best seed is cherry-picking and would not survive review; picking the median gives a representative trajectory without inflating results.
+
+**Single-seed protocol for A1–A6.** Each of A1, A2, A3, A4, A5, A6 is run once, on the canonical seed fixed from A0. The A4 sensitivity spot-check from the prior version of this document is **dropped** — seed variance is not the question this ablation is trying to answer.
+
+**Total runs: 9** (3 seed-test runs on A0 + 6 rows A1–A6 = 9 training runs).
 
 ### 4.4 Metrics
 
@@ -159,6 +157,7 @@ Empirical observations to date (informal, pre-ablation):
 - A1 ≈ 0.55 (plateau at epoch ~270).
 - A3 ≈ 0.76 (at 10k points, with ε).
 - A4 ≈ 0.98 (at 100k points, with ε).
+- Seed: the A1–A6 rows all use the canonical seed picked from the A0 seed test. A4 is no longer replicated across multiple seeds.
 
 These numbers must be **re-run under the protocol above** before they
 enter the manuscript. They are recorded here only to set expectation
@@ -198,55 +197,23 @@ The chapter follows the discovery narrative, not the ablation row order:
 
 ---
 
-## 7. Deliverables
+## 7. Deliverables (functionality-first)
 
-### 7.1 Code artifacts (to be produced)
+### 7.1 Code artifacts (in scope)
 
-- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_noeps.yaml`
-      (A2) — copy of `experiment_1_nondim_l2.yaml` with a new
-      `training.l2_eps: 0.0` key.
-- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_dense.yaml`
-      (A4) — copy with `sampling.n_points_pde: 100000` (and
-      `n_points_ic`, `n_points_bc_domain` matched to 100000).
-- [ ] Config `configs/experiment_1/experiment_1_nondim_mse_dense.yaml`
-      (A5) — copy of `experiment_1_nondim.yaml` (MSE path) with the
-      same dense-sampling settings as A4. **Critical decoupling run.**
-- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_f64.yaml`
-      (A6) — copy of A4 with `device.dtype: float64`.
-- [ ] Refactor `experiments/experiment_1/train_nondim_l2.py` to read
-      `training.l2_eps` from config (default 1e-12) so A2 and A3 share
-      one training script, and the A2 vs A3 comparison is literally a
-      one-line config diff.
-- [ ] Add **gradient-norm logging** (global ‖∇θ L‖ per epoch) to
-      `train_nondim_l2.py` output and/or tracker. This is the primary
-      diagnostic evidence for H2 and H3b — the ablation story does not
-      work without it. (If adding to the shared training loop is out
-      of scope, log it in the local custom loop.)
-- [ ] `scripts/ablation_exp1.sh` — runs A0–A6 + 2 sensitivity seeds
-      sequentially.
-- [ ] `scripts/aggregate_exp1_ablation.py` — collects per-run
-      `training_history.json` + best-NSE stats and emits §5 table as
-      both CSV and LaTeX.
+- [ ] Config `configs/experiment_1/experiment_1_A0.yaml` (A0) — dedicated baseline; mirrors `experiment_1_nondim.yaml` but with `scaling.enabled: false`. Runs under `train_nondim.py` in identity-mode so only one variable (non-dim on/off) distinguishes A0 from A1.
+- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_noeps.yaml` (A2) — copy of `experiment_1_nondim_l2.yaml` with `training.l2_eps: 0.0`.
+- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_dense.yaml` (A4) — copy with `sampling.n_points_pde: 100000` (and IC/BC counts matched).
+- [ ] Config `configs/experiment_1/experiment_1_nondim_mse_dense.yaml` (A5) — copy of `experiment_1_nondim.yaml` (MSE path) with the same dense-sampling settings as A4. Decoupling run.
+- [ ] Config `configs/experiment_1/experiment_1_nondim_l2_f64.yaml` (A6) — copy of A4 with `device.dtype: float64`.
+- [ ] Refactor `experiments/experiment_1/train_nondim_l2.py` so the sqrt epsilon reads from `training.l2_eps` (default 1e-12) — A2 and A3 share one script, differing by config only.
+- [ ] Per-epoch global ‖∇θ L‖ logging added to the shared training step → W&B (`train/grad_norm`) and `training_history.json`. Primary diagnostic for H2 and H3b.
+- [ ] One shell script per ablation row under `scripts/`: `run_exp1_A0.sh` … `run_exp1_A6.sh`, plus `run_exp1_A0_seedtest.sh` that runs A0 with seeds 42, 123, 2024.
 
-### 7.2 Figures (publication-quality, Exeter + Blue Heart palette, 300 DPI)
+### 7.2 Out of scope (deferred)
 
-- **F1.** Per-term loss trajectories A0 vs A1 (log y, 4 subplots).
-  Evidence for H1.
-- **F2.** Validation NSE(epoch) overlay for A1, A2, A3, A4 on one axis.
-  The headline "L2 escapes the plateau" figure.
-- **F3.** Global gradient norm ‖∇θ L‖(epoch) overlay for A1 (MSE), A2
-  (L2 no ε), A3 (L2 with ε). Evidence for H2 and H3b.
-- **F4.** Bar decomposition of the 0.55 → 0.98 gap into L2-component
-  (A3 − A1), sampling-component (A5 − A1), and joint-excess
-  (A4 − A3 − A5 + A1). Evidence for H4.
-- **F5.** Bar chart: final NSE and wall-clock for A4 vs A6. Evidence for
-  H5.
-
-### 7.3 Tables
-
-- **T1.** §5 headline results (7 rows + seed-sensitivity footnote on A4).
-- **T2.** Per-term loss ratios (pde:ic:bc) at epoch 500 for A0 vs A1.
-- **T3.** Hypothesis verdict table (H1–H5, pass/fail, evidence pointer).
+- Aggregation scripts (`aggregate_exp1_ablation.py`), results tables (CSV / LaTeX), and any post-training figure generation (F1–F5, T1–T3) are **deferred**. The W&B run group `exp1-ablation-v1` is the canonical record; the user will pull figures and tables from the W&B UI when writing up.
+- Inference scripts beyond the existing in-training plotting/logging are deferred.
 
 ---
 
@@ -261,10 +228,7 @@ The chapter follows the discovery narrative, not the ablation row order:
   A3 and A4, additionally report NSE under uniform `{1,1,1,1}` weights
   as a robustness check. If L2 is insensitive to weight choice, that is
   itself a finding.
-- **Single seed.** Larger variance could invalidate small deltas.
-  Mitigation: the A4 sensitivity spot-check (§4.3). Report the A4
-  3-seed std explicitly and state the single-seed protocol is only
-  justified if that std < 0.02.
+- **Single seed for A1–A6.** Seed variance is not characterised per-row. Mitigation: the A0 seed test bounds the variance at the baseline, and the canonical seed is the median of that test (not the best). If seed-to-seed differences on A0 are large (std > 0.05 NSE), this is explicitly disclosed in the write-up as a threat.
 - **Gradient-norm interpretation.** A collapsing global gradient is
   consistent with both "loss is near zero" (good) and "loss is stuck on
   a plateau" (bad). Mitigation: always plot gradient norm **alongside**
@@ -291,3 +255,5 @@ study deliberately does **not** investigate (adaptive weighting,
 architecture selection, sampling strategy, slope terms, data-driven
 training) are explicitly deferred to Experiments 2–11 as specified in
 `docs/experimental_programme_reference.md`.
+
+Thesis-writing artefacts (figures, tables, manuscript-ready LaTeX) are deferred. The immediate goal is **trainable, diagnosable runs logged to W&B** — the record of record — and the user will build the write-up artefacts directly from W&B when needed.

--- a/experiments/experiment_1/train_nondim_l2.py
+++ b/experiments/experiment_1/train_nondim_l2.py
@@ -73,19 +73,26 @@ from src.training import (
 )
 
 
-_SQRT_EPS = 1e-12
+_SQRT_EPS_DEFAULT = 1e-12
 
 
-def _l2(sum_sq):
+def _l2(sum_sq, eps):
     """True L2 norm: ``sqrt(sum(r^2) + eps)``.
 
     Callers must pass the **sum of squared residuals**, not the mean. Because
     the shared loss helpers all return ``mean(r^2)``, the call sites multiply
     by the batch count ``N`` to recover ``sum = mean * N`` before applying
-    this function. The tiny epsilon keeps the gradient ``1/(2*sqrt(x))``
-    finite near zero — see ``docs/l2_loss_experiment.md``.
+    this function. The epsilon keeps the gradient ``1/(2*sqrt(x))`` finite
+    near zero; set ``eps=0`` to recover the unstabilized L2 (ablation A2).
+    See ``docs/l2_loss_experiment.md`` and ``docs/experiment_1_ablation_design.md``.
     """
-    return jnp.sqrt(sum_sq + _SQRT_EPS)
+    return jnp.sqrt(sum_sq + eps)
+
+
+def _read_l2_eps(config) -> float:
+    """Extract the Charbonnier epsilon from config, defaulting to 1e-12."""
+    training_cfg = config.get("training", {}) if hasattr(config, "get") else {}
+    return float(training_cfg.get("l2_eps", _SQRT_EPS_DEFAULT))
 
 
 def compute_losses(model, params, batch, config, data_free, scaler=None):
@@ -97,17 +104,18 @@ def compute_losses(model, params, batch, config, data_free, scaler=None):
     one L2 norm over the concatenated boundary residual vector.
     """
     terms = {}
+    l2_eps = _read_l2_eps(config)
 
     pde_batch_data = batch.get('pde', jnp.empty((0, 3), dtype=get_dtype()))
     if pde_batch_data.shape[0] > 0:
         n_pde = pde_batch_data.shape[0]
-        terms['pde'] = _l2(compute_pde_loss(model, params, pde_batch_data, config) * n_pde)
-        terms['neg_h'] = _l2(compute_neg_h_loss(model, params, pde_batch_data) * n_pde)
+        terms['pde'] = _l2(compute_pde_loss(model, params, pde_batch_data, config) * n_pde, l2_eps)
+        terms['neg_h'] = _l2(compute_neg_h_loss(model, params, pde_batch_data) * n_pde, l2_eps)
 
     ic_batch_data = batch.get('ic', jnp.empty((0, 3), dtype=get_dtype()))
     if ic_batch_data.shape[0] > 0:
         n_ic = ic_batch_data.shape[0]
-        terms['ic'] = _l2(compute_ic_loss(model, params, ic_batch_data) * n_ic)
+        terms['ic'] = _l2(compute_ic_loss(model, params, ic_batch_data) * n_ic, l2_eps)
 
     bc_batches = batch.get('bc', {})
     if any(b.shape[0] > 0 for b in bc_batches.values() if hasattr(b, 'shape')):
@@ -143,12 +151,12 @@ def compute_losses(model, params, batch, config, data_free, scaler=None):
         loss_bottom = loss_boundary_wall_horizontal(model, params, bottom)
         loss_top = loss_boundary_wall_horizontal(model, params, top)
         n_wall = left.shape[0]
-        terms['bc'] = _l2((loss_left + loss_right + loss_bottom + loss_top) * n_wall)
+        terms['bc'] = _l2((loss_left + loss_right + loss_bottom + loss_top) * n_wall, l2_eps)
 
     data_batch_data = batch.get('data', jnp.empty((0, 6), dtype=get_dtype()))
     if not data_free and data_batch_data.shape[0] > 0:
         n_data = data_batch_data.shape[0]
-        terms['data'] = _l2(compute_data_loss(model, params, data_batch_data, config) * n_data)
+        terms['data'] = _l2(compute_data_loss(model, params, data_batch_data, config) * n_data, l2_eps)
 
     return terms
 

--- a/scripts/_exp1_ablation_common.sh
+++ b/scripts/_exp1_ablation_common.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Shared helpers for Experiment 1 ablation row scripts.
+# Sourced, not executed directly.
+#
+# Usage inside a row script:
+#   source "$(dirname "$0")/_exp1_ablation_common.sh"
+#   run_ablation_row "A0" "experiments.experiment_1.train" \
+#                    "configs/experiment_1/experiment_1.yaml"
+#
+# Env overrides:
+#   SEED              (default 42)   — training.seed override
+#   WANDB_RUN_GROUP   (default exp1-ablation-v1)
+#   EXTRA_TAGS        (default '')   — appended to WANDB_TAGS
+
+set -euo pipefail
+
+run_ablation_row() {
+    local row="$1"
+    local module="$2"
+    local base_config="$3"
+
+    local seed="${SEED:-42}"
+    local group="${WANDB_RUN_GROUP:-exp1-ablation-v1}"
+    local extra="${EXTRA_TAGS:-}"
+
+    if [[ ! -f "$base_config" ]]; then
+        echo "ERROR: config not found: $base_config" >&2
+        return 1
+    fi
+
+    local tmp_config
+    tmp_config=$(mktemp --suffix=.yaml)
+    trap "rm -f '$tmp_config'" RETURN
+
+    python - "$base_config" "$tmp_config" "$seed" <<'PY'
+import sys, yaml
+src, dst, seed = sys.argv[1], sys.argv[2], int(sys.argv[3])
+with open(src) as f:
+    cfg = yaml.safe_load(f)
+cfg.setdefault("training", {})["seed"] = seed
+with open(dst, "w") as f:
+    yaml.safe_dump(cfg, f, sort_keys=False)
+PY
+
+    local tags="exp1-ablation,row=${row},seed=${seed}"
+    if [[ -n "$extra" ]]; then
+        tags="${tags},${extra}"
+    fi
+
+    export WANDB_RUN_GROUP="$group"
+    export WANDB_TAGS="$tags"
+
+    echo "=================================================="
+    echo "Experiment 1 ablation: row=${row} seed=${seed}"
+    echo "  Module : ${module}"
+    echo "  Config : ${base_config}"
+    echo "  W&B    : group=${group}  tags=${tags}"
+    echo "=================================================="
+
+    python -m "$module" --config "$tmp_config"
+}

--- a/scripts/run_exp1_A0.sh
+++ b/scripts/run_exp1_A0.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Ablation A0 — baseline: input-normalized only, MSE, no output non-dim.
+# Uses train_nondim.py with scaling.enabled=false (identity-mode fallback) so
+# A0 differs from A1 by exactly one variable: non-dimensionalization.
+# Override seed via: SEED=123 bash scripts/run_exp1_A0.sh
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+source "$HERE/_exp1_ablation_common.sh"
+
+run_ablation_row \
+    "A0" \
+    "experiments.experiment_1.train_nondim" \
+    "configs/experiment_1/experiment_1_A0.yaml"

--- a/scripts/run_exp1_A0_seedtest.sh
+++ b/scripts/run_exp1_A0_seedtest.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# A0 seed test: runs the baseline on seeds 42, 123, 2024 sequentially.
+# The canonical seed for A1-A6 is picked as the MEDIAN-NSE seed from this run
+# (not the best — see docs/experiment_1_ablation_design.md §4.3).
+#
+# Each run is logged to the same W&B group (exp1-ablation-v1) with
+# tag seed=<N> so the three can be compared in the UI.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+
+for SEED in 42 123 2024; do
+    echo ""
+    echo "############################################"
+    echo "# A0 seed test: seed=${SEED}"
+    echo "############################################"
+    SEED="$SEED" EXTRA_TAGS="seed-test" bash "$HERE/run_exp1_A0.sh"
+done
+
+echo ""
+echo "A0 seed test complete. Pick the median-NSE seed on W&B and"
+echo "use it via SEED=<N> bash scripts/run_exp1_A<row>.sh for A1-A6."

--- a/scripts/run_exp1_A1.sh
+++ b/scripts/run_exp1_A1.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ablation A1 — A0 + non-dimensionalization (MSE loss, 10k sampling).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+source "$HERE/_exp1_ablation_common.sh"
+
+run_ablation_row \
+    "A1" \
+    "experiments.experiment_1.train_nondim" \
+    "configs/experiment_1/experiment_1_nondim.yaml"

--- a/scripts/run_exp1_A2.sh
+++ b/scripts/run_exp1_A2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ablation A2 — A1 + L2 loss without the Charbonnier epsilon (l2_eps = 0).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+source "$HERE/_exp1_ablation_common.sh"
+
+run_ablation_row \
+    "A2" \
+    "experiments.experiment_1.train_nondim_l2" \
+    "configs/experiment_1/experiment_1_nondim_l2_noeps.yaml"

--- a/scripts/run_exp1_A3.sh
+++ b/scripts/run_exp1_A3.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ablation A3 — A2 + Charbonnier epsilon stabilization (l2_eps = 1e-12).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+source "$HERE/_exp1_ablation_common.sh"
+
+run_ablation_row \
+    "A3" \
+    "experiments.experiment_1.train_nondim_l2" \
+    "configs/experiment_1/experiment_1_nondim_l2.yaml"

--- a/scripts/run_exp1_A4.sh
+++ b/scripts/run_exp1_A4.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ablation A4 — A3 + dense (100k) PDE collocation sampling. Headline row.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+source "$HERE/_exp1_ablation_common.sh"
+
+run_ablation_row \
+    "A4" \
+    "experiments.experiment_1.train_nondim_l2" \
+    "configs/experiment_1/experiment_1_nondim_l2_dense.yaml"

--- a/scripts/run_exp1_A5.sh
+++ b/scripts/run_exp1_A5.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Ablation A5 — MSE + dense (100k) sampling. Decoupling run: branches from A1,
+# not A4, to isolate whether L2 or sampling density carries the breakthrough.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+source "$HERE/_exp1_ablation_common.sh"
+
+run_ablation_row \
+    "A5" \
+    "experiments.experiment_1.train_nondim" \
+    "configs/experiment_1/experiment_1_nondim_mse_dense.yaml"

--- a/scripts/run_exp1_A6.sh
+++ b/scripts/run_exp1_A6.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Ablation A6 — A4 + float64 precision. Tests H5 (is double precision worth it?).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$HERE/.."
+source "$HERE/_exp1_ablation_common.sh"
+
+run_ablation_row \
+    "A6" \
+    "experiments.experiment_1.train_nondim_l2" \
+    "configs/experiment_1/experiment_1_nondim_l2_f64.yaml"

--- a/src/monitoring/wandb_tracker.py
+++ b/src/monitoring/wandb_tracker.py
@@ -205,6 +205,7 @@ class WandbTracker:
         epoch_time: float,
         elapsed_time: float,
         neg_depth: Optional[dict] = None,
+        grad_norm: Optional[float] = None,
     ):
         """Log per-epoch metrics.
 
@@ -236,6 +237,12 @@ class WandbTracker:
 
             # Learning rate
             metrics["train/lr"] = _safe_float(lr)
+
+            # Global gradient norm (per-epoch mean across micro-batches)
+            if grad_norm is not None:
+                gn_f = _safe_float(grad_norm)
+                if not math.isnan(gn_f) and not math.isinf(gn_f):
+                    metrics["train/grad_norm"] = gn_f
 
             # Validation metrics (skip NaN — e.g. hv in 1D experiments)
             for key, val in val_metrics.items():

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -134,6 +134,12 @@ def run_training_loop(
             avg_losses_unweighted = {k: float(v) / num_batches for k, v in epoch_losses_sum.items()}
             avg_total_weighted_loss = float(epoch_total_sum) / num_batches
 
+            # Separate grad-norm diagnostic from training losses (it enters via
+            # train_step under the reserved key "_grad_norm"). Logged to W&B
+            # and training_history.json under train/grad_norm but never
+            # contributes to the total loss.
+            avg_grad_norm = avg_losses_unweighted.pop("_grad_norm", None)
+
             current_lr = extract_lr(opt_state, cfg["training"]["learning_rate"], epoch)
 
             # Validation
@@ -230,7 +236,7 @@ def run_training_loop(
                 )
 
             elapsed_now = time.time() - start_time
-            epoch_history.append({
+            epoch_record = {
                 'epoch': int(epoch),
                 'total_loss': float(avg_total_weighted_loss),
                 'losses': {k: float(v) for k, v in avg_losses_unweighted.items()},
@@ -238,7 +244,10 @@ def run_training_loop(
                 'lr': float(current_lr),
                 'epoch_time_s': float(epoch_time),
                 'elapsed_time_s': float(elapsed_now),
-            })
+            }
+            if avg_grad_norm is not None:
+                epoch_record['grad_norm'] = float(avg_grad_norm)
+            epoch_history.append(epoch_record)
 
             tracker.log_epoch(
                 epoch=epoch, step=global_step,
@@ -246,6 +255,7 @@ def run_training_loop(
                 val_metrics=val_metrics, lr=current_lr,
                 epoch_time=epoch_time, elapsed_time=elapsed_now,
                 neg_depth=neg_depth if (epoch + 1) % freq == 0 else None,
+                grad_norm=avg_grad_norm,
             )
 
             # Early stopping

--- a/src/training/step.py
+++ b/src/training/step.py
@@ -43,6 +43,8 @@ def train_step(
         return total, terms
 
     (loss_val, metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(params)
+    grad_norm = optax.global_norm(grads)
+    metrics = {**metrics, "_grad_norm": grad_norm}
     updates, new_opt_state = optimiser.update(grads, opt_state, params, value=loss_val)
     new_params = optax.apply_updates(params, updates)
     return new_params, new_opt_state, metrics, loss_val


### PR DESCRIPTION
## Summary

Lands everything needed to actually **run** the Experiment 1 ablation chain specified in `docs/experiment_1_ablation_design.md`. No aggregation / no figure generation / no post-training inference — W&B (run group `exp1-ablation-v1`) is the canonical record; thesis-writing artefacts are deferred until the user comes back to write them up.

## What's new

### Training infrastructure
- **Per-epoch global gradient-norm logging** added at the shared training-step level. Computed as `optax.global_norm(grads)` in `src/training/step.py`, threaded through the scan body under the reserved key `_grad_norm` (backwards-compatible — no signature changes), separated out in `src/training/loop.py`, and logged to W&B as `train/grad_norm` plus written to `training_history.json`. Primary diagnostic for H2 (MSE gradient flatness) and H3b (sqrt-gradient instability without ε).
- **`l2_eps` is now config-driven** in `train_nondim_l2.py`. A2 (ε = 0) and A3 (ε = 1e-12) share the same train script; they differ by a single config key.

### Configs (one per row)
| Row | Config | Change vs previous row |
|-----|--------|------------------------|
| A0 | `experiment_1_A0.yaml` *(new)* | baseline: `scaling.enabled: false` |
| A1 | `experiment_1_nondim.yaml` | + output non-dim |
| A2 | `experiment_1_nondim_l2_noeps.yaml` *(new)* | MSE → L2, ε = 0 |
| A3 | `experiment_1_nondim_l2.yaml` *(updated)* | + ε = 1e-12 |
| A4 | `experiment_1_nondim_l2_dense.yaml` *(new)* | + 100k PDE points |
| A5 | `experiment_1_nondim_mse_dense.yaml` *(new)* | **decoupling**: MSE + 100k (branches from A1) |
| A6 | `experiment_1_nondim_l2_f64.yaml` *(new)* | + float64 |

### Run scripts
- `scripts/_exp1_ablation_common.sh` — shared helper; patches `SEED` env var into a temp config, sets `WANDB_RUN_GROUP=exp1-ablation-v1` and `WANDB_TAGS=exp1-ablation,row=<N>,seed=<S>`.
- `scripts/run_exp1_A0.sh` … `run_exp1_A6.sh` — one launcher per row.
- `scripts/run_exp1_A0_seedtest.sh` — runs A0 on seeds 42, 123, 2024 sequentially. Pick the **median-NSE** seed (not the best — avoids cherry-picking) and export it for A1–A6 via `SEED=<N> bash scripts/run_exp1_A<row>.sh`.

### Docs
- `docs/experiment_1_ablation_design.md` revised: seed *test* on A0 replaces the per-row sensitivity sweep; cosine LR formally excluded from scope (tested, same plateau); deliverables narrowed to in-scope code + deferred items; A4 multi-seed spot-check dropped.
- `CLAUDE.md` gains Git Workflow, Repo Organization, and Artifact Organization sections (main-branch PRs, `models/archive/` convention).

## Verification
- `python -m unittest test.test_losses test.test_physics test.test_train` → **32 tests OK**.
- `python -m unittest test.test_experiment_1_nondim` → **3 tests OK**.
- `bash -n` passes on every `scripts/run_exp1_A*.sh`.
- Seed-patch round-trip verified (`training.seed == SEED` after yaml dump/load).

## Out of scope (deferred — do not ask me to add these in this PR)
- Aggregation scripts, CSV/LaTeX tables, post-training figure generation.
- Inference scripts beyond in-training plotting.
- Hard-constraint variant — parked on `feat/exp1-hard-bc` (separate PR later).

## Test plan
- [x] Regression tests pass on CPU.
- [ ] `bash scripts/run_exp1_A0_seedtest.sh` on GPU → 3 A0 runs land in W&B under `exp1-ablation-v1`.
- [ ] Pick median-NSE seed from A0 test and run A1–A6.
- [ ] Confirm `train/grad_norm` plot is populated for each row.